### PR TITLE
feat: add assignment duration column to PIC list

### DIFF
--- a/resources/views/supplier/pic/list.blade.php
+++ b/resources/views/supplier/pic/list.blade.php
@@ -264,6 +264,7 @@
                 <th>Nama PIC</th>
                 <th>Email</th>
                 <th>Telephone</th>
+                <th>Durasi Penugasan</th>
                 <th>Actions</th>
               </tr>
             </thead>
@@ -275,6 +276,16 @@
                 <td>{{ $pic->name }}</td>
                 <td>{{ $pic->email }}</td>
                 <td>{{ $pic->phone_number }}</td>
+                <td>
+                  @php
+                    $duration = json_decode(\App\Models\SupplierPic::assignmentDuration($pic));
+                  @endphp
+                  @if(is_object($duration))
+                    {{ $duration->years }} tahun, {{ $duration->months }} bulan, {{ $duration->days }} hari
+                  @else
+                    Tanggal belum tersedia
+                  @endif
+                </td>
                 <td>
                   <a href="/supplier/pic/detail/{{ $pic->id }}" class="btn btn-sm btn-info">Detail</a>
                   <a href="#" class="btn btn-sm btn-primary">Edit</a>


### PR DESCRIPTION
This pull request updates the supplier PIC list view to include a new column displaying the assignment duration for each PIC. The most important changes involve adding this new column in the table header and dynamically calculating and displaying the assignment duration in the table rows.

### Changes to the supplier PIC list view:

* **Added "Durasi Penugasan" column to the table header**: A new column was added to display the assignment duration for each PIC. (`resources/views/supplier/pic/list.blade.php`, [resources/views/supplier/pic/list.blade.phpR267](diffhunk://#diff-1436382c3df81ae34ab386797dcbfd65d3ed0f7d59afd1909f4c0252629f3585R267))
* **Implemented assignment duration display logic**: The assignment duration is calculated using the `assignmentDuration` method from the `SupplierPic` model. If the duration data is available, it is displayed in years, months, and days; otherwise, a fallback message is shown. (`resources/views/supplier/pic/list.blade.php`, [resources/views/supplier/pic/list.blade.phpR279-R288](diffhunk://#diff-1436382c3df81ae34ab386797dcbfd65d3ed0f7d59afd1909f4c0252629f3585R279-R288))