### PR TITLE
Fix: Menambahkan definisi pesan dan memperbarui penggunaannya di ProductController dan pengujian terkait

### DIFF
--- a/app/Constants/Messages.php
+++ b/app/Constants/Messages.php
@@ -60,6 +60,9 @@ class Messages
     public const CATEGORY_NAME_TOO_SHORT = 'Nama kategori minimal 3 karakter!';
     public const CATEGORY_NAME_INVALID = 'Nama kategori hanya boleh berisi huruf, angka, spasi, dash, underscore, dan titik!';
 
+    // Product messages
+    public const PRODUCT_NOT_FOUND = 'Produk tidak ditemukan';
+
     // General
     public const ACTION_FAILED = 'Aksi gagal dilakukan!';
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -8,6 +8,7 @@ use Barryvdh\DomPDF\Facade\Pdf;
 use App\Helpers\EncryptionHelper;
 use App\Enums\ProductType;
 use App\Models\Category;
+use App\Constants\Messages;
 
 
 class ProductController extends Controller
@@ -38,7 +39,7 @@ class ProductController extends Controller
         $product = (new Product())->getProductById($productId);
 
         if (!$product) {
-            return response()->view('errors.404', ['message' => 'Product tidak ditemukan'], 404);
+            return response()->view('errors.404', ['message' => Messages::PRODUCT_NOT_FOUND], 404);
         }
        return view('product.detail', compact('product'));
     }

--- a/tests/Feature/Controllers/ProductControllerTest.php
+++ b/tests/Feature/Controllers/ProductControllerTest.php
@@ -8,6 +8,7 @@ use Tests\TestCase;
 use App\Models\Product;
 use App\Models\Category;
 use App\Constants\ProductColumns;
+use App\Constants\Messages;
 use App\Helpers\EncryptionHelper;
 
 class ProductControllerTest extends TestCase
@@ -83,7 +84,7 @@ class ProductControllerTest extends TestCase
 
         // Assert 404 response
         $response->assertStatus(404);
-        $response->assertSee('Product tidak ditemukan');
+        $response->assertSee(Messages::PRODUCT_NOT_FOUND); // Updated: menggunakan konstanta Messages
     }
 
     /**

--- a/tests/Feature/Controllers/ProductControllerTest.php
+++ b/tests/Feature/Controllers/ProductControllerTest.php
@@ -84,7 +84,7 @@ class ProductControllerTest extends TestCase
 
         // Assert 404 response
         $response->assertStatus(404);
-        $response->assertSee(Messages::PRODUCT_NOT_FOUND); // Updated: menggunakan konstanta Messages
+        $response->assertSee(Messages::PRODUCT_NOT_FOUND);
     }
 
     /**


### PR DESCRIPTION
This pull request improves the handling of "product not found" error messages by centralizing the message definition and updating its usage in both the controller and related tests. The main goal is to ensure consistency and maintainability of error messages across the codebase.

**Error message centralization and usage:**

* Added a new constant `PRODUCT_NOT_FOUND` to the `Messages` class for the "product not found" error message.
* Updated `ProductController` to use `Messages::PRODUCT_NOT_FOUND` when returning a 404 error for a missing product.
* Updated the product controller feature test to assert against the centralized `PRODUCT_NOT_FOUND` message instead of a hardcoded string.

**Imports and dependencies:**

* Imported the `Messages` class in both `ProductController.php` and `ProductControllerTest.php` to support usage of the new constant. [[1]](diffhunk://#diff-d4d289295cb32b9455781e35829f66fe8e508a92246ac52e3e0c78b24b7eec97R11) [[2]](diffhunk://#diff-9447d70f2edad3e7b2ea4c414bac3f309a8ce77319a1a7b26298bbad323342a9R11)

**testing Image:**
<img width="963" height="252" alt="image" src="https://github.com/user-attachments/assets/6b4d32df-594d-4afb-9adf-bf5ee24785c7" />

