### PR TITLE
Add unit testing for supplierPIC controller method GetPICByID

### DIFF
--- a/app/Constants/Messages.php
+++ b/app/Constants/Messages.php
@@ -66,6 +66,14 @@ class Messages
     // Item messages
     public const ITEM_IN_USE = 'Item tidak bisa dihapus karena sudah digunakan di purchase order.';
 
+    // Supplier PIC messages
+    public const SUPPLIER_PIC_NOT_FOUND = 'PIC tidak ditemukan.';
+    public const SUPPLIER_PIC_CREATED = 'PIC berhasil ditambahkan!';
+    public const SUPPLIER_PIC_UPDATED = 'PIC berhasil diupdate!';
+    public const SUPPLIER_PIC_DELETED = 'PIC berhasil dihapus!';
+    public const SUPPLIER_PIC_DELETE_FAILED = 'PIC gagal dihapus.';
+    public const SUPPLIER_PIC_DUPLICATE = 'Data PIC dengan informasi yang sama sudah ada dan tidak bisa disimpan.';
+
     // General
     public const ACTION_FAILED = 'Aksi gagal dilakukan!';
 }

--- a/app/Http/Controllers/SupplierPIController.php
+++ b/app/Http/Controllers/SupplierPIController.php
@@ -28,7 +28,7 @@ class SupplierPIController extends Controller
         }
 
         $supplier = $pic->supplier;
-        $pic->supplier_name = $supplier ? $supplier->name : null;
+        $pic->supplier_name = $supplier ? $supplier->company_name : null;
         return view('supplier.pic.detail', ['pic' => $pic, 'supplier' => $supplier]);
     }
 

--- a/app/Models/SupplierPICModel.php
+++ b/app/Models/SupplierPICModel.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class SupplierPICModel extends Model
 {
+    use HasFactory;
+    
     protected $table = 'supplier_pics';
 
     protected $fillable = [

--- a/app/Models/SupplierPic.php
+++ b/app/Models/SupplierPic.php
@@ -7,17 +7,17 @@ use Carbon\Carbon;
 
 class SupplierPic extends Model
 {
-    protected $table = 'supplier_pic'; // sesuaikan nama tabel
+    protected $table = 'supplier_pics'; // sesuaikan nama tabel
     protected $fillable = ['name', 'email', 'phone_number', 'supplier_id'];
     protected $primaryKey = 'id';
-    public $incrementing = false;
-    protected $keyType = 'string';
+    public $incrementing = true; // ID is auto-increment
+    protected $keyType = 'int'; // ID is integer
 
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
 
-        $this->table = config('db_constants.table.supplier_pic');
+        $this->table = config('db_tables.supplier_pic');
         $this->fillable = array_values(config('db_constants.column.supplier_pic') ?? []);
     }
 

--- a/database/factories/SupplierPICFactory.php
+++ b/database/factories/SupplierPICFactory.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SupplierPICModel;
+use App\Models\Supplier;
+use App\Constants\SupplierPicColumns;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\SupplierPICModel>
+ */
+class SupplierPICFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = SupplierPICModel::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            SupplierPicColumns::SUPPLIER_ID => 'SUP001',
+            SupplierPicColumns::NAME => $this->faker->name(),
+            SupplierPicColumns::PHONE => $this->faker->phoneNumber(),
+            SupplierPicColumns::EMAIL => $this->faker->unique()->safeEmail(),
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => $this->faker->date('Y-m-d', '-1 year'),
+        ];
+    }
+
+    /**
+     * Indicate that the PIC is inactive.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            SupplierPicColumns::IS_ACTIVE => false,
+        ]);
+    }
+
+    /**
+     * Indicate that the PIC is active.
+     */
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            SupplierPicColumns::IS_ACTIVE => true,
+        ]);
+    }
+
+    /**
+     * Set specific supplier ID.
+     */
+    public function forSupplier(string $supplierId): static
+    {
+        return $this->state(fn (array $attributes) => [
+            SupplierPicColumns::SUPPLIER_ID => $supplierId,
+        ]);
+    }
+
+    /**
+     * Set specific assigned date.
+     */
+    public function assignedOn(string $date): static
+    {
+        return $this->state(fn (array $attributes) => [
+            SupplierPicColumns::ASSIGNED_DATE => $date,
+        ]);
+    }
+
+    /**
+     * Create PIC with specific name.
+     */
+    public function withName(string $name): static
+    {
+        return $this->state(fn (array $attributes) => [
+            SupplierPicColumns::NAME => $name,
+        ]);
+    }
+}

--- a/database/migrations/2025_01_05_113648_create_supplier_pic_table.php
+++ b/database/migrations/2025_01_05_113648_create_supplier_pic_table.php
@@ -7,6 +7,8 @@ use App\Constants\SupplierPicColumns;
 
 return new class extends Migration
 {
+    protected string $table;
+
     public function __construct()
     {
         $this->table = config('db_tables.supplier_pic');

--- a/tests/Feature/Controllers/SupplierPIControllerTest.php
+++ b/tests/Feature/Controllers/SupplierPIControllerTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\Models\SupplierPICModel;
 use App\Models\Supplier;
 use App\Constants\SupplierPicColumns;
+use App\Constants\Messages;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\DB;
@@ -288,4 +289,288 @@ class SupplierPIControllerTest extends TestCase
         $this->assertEquals('First PIC', $result->first()->name);
         $this->assertEquals('Second PIC', $result->last()->name);
     }
+
+    // ========== GET PIC BY ID METHOD TESTS ==========
+
+    /**
+     * TC-SPIC-01
+     * Test: Get PIC by valid ID returns PIC detail page
+     * 
+     * Scenario: User requests PIC detail dengan ID yang valid
+     * Expected: Halaman detail PIC ditampilkan dengan informasi lengkap
+     */
+    public function test_get_pic_by_valid_id_returns_detail_page()
+    {
+        // ARRANGE - Create test supplier and PIC
+        $this->createSupplier('SUP001', 'Test Company');
+        
+        $pic = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP001',
+            SupplierPicColumns::NAME => 'John Doe',
+            SupplierPicColumns::PHONE => '081234567890',
+            SupplierPicColumns::EMAIL => 'john@example.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-01-15',
+        ]);
+
+        // ACT - Request PIC detail page
+        $response = $this->get("/supplier/pic/detail/{$pic->id}");
+
+        // ASSERT - Verify successful response
+        $response->assertStatus(200);
+        $response->assertViewIs('supplier.pic.detail');
+        $response->assertViewHas('pic');
+        $response->assertViewHas('supplier');
+        
+        // Verify view data contains correct PIC information
+        $viewPic = $response->viewData('pic');
+        $this->assertEquals($pic->id, $viewPic->id);
+        $this->assertEquals('John Doe', $viewPic->name);
+        $this->assertEquals('081234567890', $viewPic->phone_number);
+        $this->assertEquals('john@example.com', $viewPic->email);
+        $this->assertEquals('Test Company', $viewPic->supplier_name);
+    }
+
+    /**
+     * TC-SPIC-02
+     * Test: Get PIC by invalid ID redirects with error
+     * 
+     * Scenario: User requests PIC detail dengan ID yang tidak ada
+     * Expected: Redirect ke halaman supplier dengan error message
+     */
+    public function test_get_pic_by_invalid_id_redirects_with_error()
+    {
+        // ARRANGE - No PIC created, use non-existent ID
+        $invalidId = 99999;
+
+        // ACT - Request non-existent PIC detail
+        $response = $this->get("/supplier/pic/detail/{$invalidId}");
+
+        // ASSERT - Verify redirect with error
+        $response->assertStatus(302);
+        $response->assertRedirect('/supplier');
+        $response->assertSessionHas('error', Messages::SUPPLIER_PIC_NOT_FOUND);
+    }
+
+    /**
+     * TC-SPIC-03
+     * Test: Get PIC with supplier relationship loaded
+     * 
+     * Scenario: PIC detail harus menampilkan informasi supplier terkait
+     * Expected: View contains both PIC and supplier information
+     */
+    public function test_get_pic_loads_supplier_relationship()
+    {
+        // ARRANGE - Create supplier and PIC
+        $this->createSupplier('SUP002', 'ABC Corporation');
+        
+        $pic = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP002',
+            SupplierPicColumns::NAME => 'Jane Smith',
+            SupplierPicColumns::PHONE => '081987654321',
+            SupplierPicColumns::EMAIL => 'jane@abc.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-02-01',
+        ]);
+
+        // ACT - Request PIC detail
+        $response = $this->get("/supplier/pic/detail/{$pic->id}");
+
+        // ASSERT - Verify supplier data is loaded
+        $response->assertStatus(200);
+        $viewPic = $response->viewData('pic');
+        $viewSupplier = $response->viewData('supplier');
+        
+        $this->assertNotNull($viewSupplier);
+        $this->assertEquals('SUP002', $viewSupplier->supplier_id);
+        $this->assertEquals('ABC Corporation', $viewSupplier->company_name);
+        $this->assertEquals('ABC Corporation', $viewPic->supplier_name);
+    }
+
+    /**
+     * TC-SPIC-04
+     * Test: Get multiple PICs with different IDs
+     * 
+     * Scenario: Verify correct PIC is returned for each unique ID
+     * Expected: Each request returns the correct PIC data
+     */
+    public function test_get_multiple_pics_by_different_ids()
+    {
+        // ARRANGE - Create supplier and multiple PICs
+        $this->createSupplier('SUP003', 'Multi PIC Company');
+        
+        $pic1 = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP003',
+            SupplierPicColumns::NAME => 'First PIC',
+            SupplierPicColumns::PHONE => '081111111111',
+            SupplierPicColumns::EMAIL => 'first@example.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-01-01',
+        ]);
+        
+        $pic2 = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP003',
+            SupplierPicColumns::NAME => 'Second PIC',
+            SupplierPicColumns::PHONE => '082222222222',
+            SupplierPicColumns::EMAIL => 'second@example.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-02-01',
+        ]);
+
+        // ACT - Request each PIC detail
+        $response1 = $this->get("/supplier/pic/detail/{$pic1->id}");
+        $response2 = $this->get("/supplier/pic/detail/{$pic2->id}");
+
+        // ASSERT - Verify each response returns correct PIC
+        $response1->assertStatus(200);
+        $viewPic1 = $response1->viewData('pic');
+        $this->assertEquals('First PIC', $viewPic1->name);
+        $this->assertEquals('081111111111', $viewPic1->phone_number);
+        
+        $response2->assertStatus(200);
+        $viewPic2 = $response2->viewData('pic');
+        $this->assertEquals('Second PIC', $viewPic2->name);
+        $this->assertEquals('082222222222', $viewPic2->phone_number);
+    }
+
+    /**
+     * TC-SPIC-05
+     * Test: Get PIC with string ID (boundary test)
+     * 
+     * Scenario: Test behavior with non-numeric ID
+     * Expected: Redirect with error message
+     */
+    public function test_get_pic_with_string_id()
+    {
+        // ARRANGE - Use string ID
+        $stringId = 'invalid-string-id';
+
+        // ACT - Request PIC with string ID
+        $response = $this->get("/supplier/pic/detail/{$stringId}");
+
+        // ASSERT - Verify redirect with error
+        $response->assertStatus(302);
+        $response->assertRedirect('/supplier');
+        $response->assertSessionHas('error', Messages::SUPPLIER_PIC_NOT_FOUND);
+    }
+
+    /**
+     * TC-SPIC-06
+     * Test: Get PIC with negative ID (boundary test)
+     * 
+     * Scenario: Test behavior with negative ID
+     * Expected: Redirect with error message
+     */
+    public function test_get_pic_with_negative_id()
+    {
+        // ARRANGE - Use negative ID
+        $negativeId = -1;
+
+        // ACT - Request PIC with negative ID
+        $response = $this->get("/supplier/pic/detail/{$negativeId}");
+
+        // ASSERT - Verify redirect with error
+        $response->assertStatus(302);
+        $response->assertRedirect('/supplier');
+        $response->assertSessionHas('error', Messages::SUPPLIER_PIC_NOT_FOUND);
+    }
+
+    /**
+     * TC-SPIC-07
+     * Test: Get PIC with zero ID (boundary test)
+     * 
+     * Scenario: Test behavior with ID = 0
+     * Expected: Redirect with error message
+     */
+    public function test_get_pic_with_zero_id()
+    {
+        // ARRANGE - Use zero ID
+        $zeroId = 0;
+
+        // ACT - Request PIC with zero ID
+        $response = $this->get("/supplier/pic/detail/{$zeroId}");
+
+        // ASSERT - Verify redirect with error
+        $response->assertStatus(302);
+        $response->assertRedirect('/supplier');
+        $response->assertSessionHas('error', Messages::SUPPLIER_PIC_NOT_FOUND);
+    }
+
+    /**
+     * TC-SPIC-08
+     * Test: Get PIC by ID calls model method correctly
+     * 
+     * Scenario: Verify controller uses SupplierPic::getPICByID() method
+     * Expected: Model method is called with correct parameter
+     */
+    public function test_get_pic_by_id_calls_model_method()
+    {
+        // ARRANGE - Create test data
+        $this->createSupplier('SUP004', 'Method Test Company');
+        
+        $pic = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP004',
+            SupplierPicColumns::NAME => 'Method Test PIC',
+            SupplierPicColumns::PHONE => '083333333333',
+            SupplierPicColumns::EMAIL => 'method@example.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-04-01',
+        ]);
+
+        // ACT - Request PIC detail
+        $response = $this->get("/supplier/pic/detail/{$pic->id}");
+
+        // ASSERT - Verify model returns correct data
+        // This implicitly tests that getPICByID() is working
+        $response->assertStatus(200);
+        $viewPic = $response->viewData('pic');
+        $this->assertEquals($pic->id, $viewPic->id);
+        $this->assertEquals('Method Test PIC', $viewPic->name);
+    }
+
+    /**
+     * TC-SPIC-09
+     * Test: Get PIC detail with all fields populated
+     * 
+     * Scenario: Verify all PIC fields are correctly displayed
+     * Expected: All fields (id, name, phone, email, etc.) are present in view
+     */
+    public function test_get_pic_detail_with_all_fields()
+    {
+        // ARRANGE - Create PIC with all fields
+        $this->createSupplier('SUP005', 'Complete Data Company');
+        
+        $pic = SupplierPICModel::create([
+            SupplierPicColumns::SUPPLIER_ID => 'SUP005',
+            SupplierPicColumns::NAME => 'Complete PIC',
+            SupplierPicColumns::PHONE => '084444444444',
+            SupplierPicColumns::EMAIL => 'complete@example.com',
+            SupplierPicColumns::IS_ACTIVE => true,
+            SupplierPicColumns::ASSIGNED_DATE => '2024-05-01',
+        ]);
+
+        // ACT - Request PIC detail
+        $response = $this->get("/supplier/pic/detail/{$pic->id}");
+
+        // ASSERT - Verify all fields are present
+        $response->assertStatus(200);
+        $viewPic = $response->viewData('pic');
+        
+        $this->assertNotNull($viewPic->id);
+        $this->assertNotNull($viewPic->supplier_id);
+        $this->assertNotNull($viewPic->name);
+        $this->assertNotNull($viewPic->phone_number);
+        $this->assertNotNull($viewPic->email);
+        $this->assertNotNull($viewPic->is_active);
+        $this->assertNotNull($viewPic->assigned_date);
+        
+        // Verify specific values
+        $this->assertEquals('Complete PIC', $viewPic->name);
+        $this->assertEquals('084444444444', $viewPic->phone_number);
+        $this->assertEquals('complete@example.com', $viewPic->email);
+        $this->assertEquals(1, $viewPic->is_active); // Database returns 1 for true
+        $this->assertEquals('2024-05-01', $viewPic->assigned_date);
+    }
+
+    
 }


### PR DESCRIPTION
This pull request introduces and tests the "Get PIC by ID" feature for supplier PICs (Person In Charge). It adds comprehensive feature tests for retrieving PIC details by ID, improves message constants for supplier PIC operations, and makes several adjustments to related models and factories to support the new and existing functionality.

The most important changes are:

**Feature: Get PIC by ID**

* Added extensive feature tests in `SupplierPIControllerTest.php` for the "Get PIC by ID" feature, covering valid/invalid IDs, boundary cases, supplier relationship loading, and field completeness.
* Updated the controller logic to set the `supplier_name` field using the supplier's `company_name` instead of `name` for consistency.

**Testing & Factories**

* Introduced a new factory `SupplierPICFactory` for generating test data for `SupplierPICModel`, including state methods for active/inactive status and custom attributes.
* Enabled the `HasFactory` trait in `SupplierPICModel` to support model factories in testing.

**Model & Migration Consistency**

* Updated `SupplierPic` model to use the correct table name (`supplier_pics`), set the primary key to auto-incrementing integer, and adjusted configuration usage for table and column names.
* Modified the migration for the supplier PIC table to use the configured table name via a protected property.

**Constants**

* Added new message constants in `Messages` for supplier PIC CRUD operations and error handling, improving code readability and maintainability.

**Test Imports**

* Added `Messages` constant import to the feature test to support error message assertions.

**Testing Images**
<img width="693" height="332" alt="image" src="https://github.com/user-attachments/assets/dc42d4b8-a836-4a13-a8c0-e05f0ac1657b" />
