### PR TITLE
feat(SupplierMaterial): Implementasi supplierMaterialSearch dan Unit …

### DIFF
--- a/app/Http/Controllers/SupplierMaterialController.php
+++ b/app/Http/Controllers/SupplierMaterialController.php
@@ -29,9 +29,9 @@ class SupplierMaterialController extends Controller
         return view('supplier.material.detail', ['material' => $material]);
     }
 
-     // Validasi data supplier material
-     public function addSupplierMaterial(Request $request)
-     {
+    // Validasi data supplier material
+    public function addSupplierMaterial(Request $request)
+    {
         $validated = $request->validate([
             'supplier_id'   => 'required|string|size:6',
             'company_name'  => 'required|string|max:255', 
@@ -42,8 +42,8 @@ class SupplierMaterialController extends Controller
             'updated_at'    => 'nullable|date',
         ]);
         SupplierMaterial::addSupplierMaterial((object)$validated);
-         return redirect()->back()->with('success', 'Data supplier product berhasil divalidasi!'); 
-     }
+        return redirect()->back()->with('success', 'Data supplier product berhasil divalidasi!'); 
+    }
 
     public function updateSupplierMaterial(Request $request, $id)
     {
@@ -79,7 +79,31 @@ class SupplierMaterialController extends Controller
         return $pdf->stream('data_material_' . $supplier_id . '.pdf');
     }
 
-        public function getSupplierMaterialByProductType($supplier_id, $product_type)
+    /**
+     * Metode Baru: Mencari Material Pemasok berdasarkan kata kunci.
+     * Ini adalah metode yang diperlukan agar tes unit Anda tidak gagal.
+     *
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function supplierMaterialSearch(Request $request)
+    {
+        // 1. Ambil kata kunci dari request.
+        $keyword = $request->input('keyword');
+
+        // 2. Memanggil metode static 'supplierMaterialSearch' dari Model.
+        // Tes Unit Anda memverifikasi baris kode inilah yang dieksekusi!
+        $supplierMaterials = SupplierMaterial::supplierMaterialSearch($keyword);
+
+        // 3. Mengembalikan View dengan data hasil dan keyword.
+        // Nama view 'supplier.material.list' harus ada di proyek Anda.
+        return view('supplier.material.list', [
+            'supplierMaterials' => $supplierMaterials,
+            'searchKeyword' => $keyword,
+        ]);
+    }
+
+    public function getSupplierMaterialByProductType($supplier_id, $product_type)
     {
         // Validasi hanya menerima product_type tertentu
         if (!in_array($product_type, ['HFG', 'FG', 'RM'])) {
@@ -106,6 +130,4 @@ class SupplierMaterialController extends Controller
 
         return response()->json($results);
     }
-
-
 }

--- a/tests/Unit/Controllers/SupplierMaterialControllerTest.php
+++ b/tests/Unit/Controllers/SupplierMaterialControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit\Controllers;
+
+use Tests\TestCase; // Kunci perbaikan untuk "TestCase not found"
+use App\Models\SupplierMaterial;
+use Illuminate\Http\Request;
+use Mockery; 
+use Illuminate\View\View;
+
+// Catatan: use RefreshDatabase dihapus untuk menghindari error koneksi DB di lingkungan testing.
+
+class SupplierMaterialControllerTest extends TestCase
+{
+    /**
+     * Metode ini akan dijalankan setelah setiap tes untuk membersihkan Mockery.
+     */
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     * Memverifikasi bahwa metode supplierMaterialSearch di controller memanggil
+     * metode supplierMaterialSearch dari Model SupplierMaterial (sesuai tugas).
+     * * Test ini menggunakan Mocking dan tidak memerlukan koneksi database.
+     */
+    public function it_calls_supplierMaterialSearch_from_model()
+    {
+        // 1. Persiapan (Arrange)
+        $keyword = 'baja';
+        $mockResults = collect([
+            (object)['id' => 101, 'name' => 'Baja Ringan'],
+            (object)['id' => 102, 'name' => 'Baja Berat'],
+        ]);
+
+        // Mocking: Mengganti Model SupplierMaterial dengan mock object (alias)
+        // Ini memastikan kita tidak benar-benar menyentuh database.
+        $supplierMaterialMock = Mockery::mock('alias:'.SupplierMaterial::class);
+        
+        // Verifikasi: Memastikan bahwa static method 'supplierMaterialSearch' dipanggil 1 kali 
+        // dengan $keyword yang benar, dan mengembalikan data dummy.
+        $supplierMaterialMock
+            ->shouldReceive('supplierMaterialSearch')
+            ->once()
+            ->with($keyword)
+            ->andReturn($mockResults);
+
+        // Membuat instance Request dengan keyword
+        $request = Request::create('/supplier/material/search', 'GET', ['keyword' => $keyword]);
+
+        // Membuat instance Controller
+        $controller = new \App\Http\Controllers\SupplierMaterialController();
+
+        // 2. Eksekusi (Act)
+        $response = $controller->supplierMaterialSearch($request);
+
+        // 3. Verifikasi (Assert)
+        
+        // Memverifikasi bahwa respons adalah View
+        $this->assertInstanceOf(View::class, $response);
+
+        // Memverifikasi bahwa view yang dikembalikan benar
+        $this->assertEquals('supplier.material.list', $response->getName());
+
+        // Memverifikasi bahwa data 'supplierMaterials' di view sesuai dengan mock results
+        $this->assertEquals($mockResults, $response->getData()['supplierMaterials']);
+
+        // Memverifikasi bahwa keyword pencarian juga dilewatkan ke view
+        $this->assertEquals($keyword, $response->getData()['searchKeyword']);
+    }
+}


### PR DESCRIPTION

<img width="1312" height="274" alt="image" src="https://github.com/user-attachments/assets/aedd66e1-a6c0-49bd-810f-1ff3bd6d1488" />


Implementasi dan verifikasi fungsionalitas pencarian material pemasok sesuai dengan spesifikasi Unit Test yang diberikan:
"SupplierMaterialController: supplierMaterialSearch($keyword) harus **memanggil supplierMaterialSearch($keyword) dari model**."

Perubahan yang Dilakukan

app/Http/Controllers/SupplierMaterialController.php (MODIFIED):

Menambahkan metode public function supplierMaterialSearch(Request $request) untuk menangani permintaan pencarian.

Di dalam metode tersebut, ditambahkan pemanggilan ke Model: SupplierMaterial::supplierMaterialSearch($keyword);

tests/Unit/Controllers/SupplierMaterialControllerTest.php (NEW FILE):

Menambahkan Unit Test baru: it_calls_supplierMaterialSearch_from_model().

Menggunakan Mocking (Mockery) untuk memastikan Controller memanggil metode static di Model tanpa perlu koneksi database (mengatasi masalah Access Denied di lingkungan XAMPP).

Menghapus use RefreshDatabase; untuk menghindari error koneksi database.