### PR TITLE
Feat: Add unit tests for the addPurchaseOrder method in PurchaseOrderController

### DIFF
--- a/app/Constants/Messages.php
+++ b/app/Constants/Messages.php
@@ -66,6 +66,10 @@ class Messages
     // Item messages
     public const ITEM_IN_USE = 'Item tidak bisa dihapus karena sudah digunakan di purchase order.';
 
+    // Purchase Order messages
+    public const PO_CREATED = 'Purchase Order berhasil ditambahkan.';
+    public const PO_CREATE_FAILED = 'Gagal menambahkan PO: ';
+
     // General
     public const ACTION_FAILED = 'Aksi gagal dilakukan!';
 }

--- a/app/Http/Controllers/PurchaseOrderController.php
+++ b/app/Http/Controllers/PurchaseOrderController.php
@@ -9,6 +9,7 @@ use App\Models\Supplier;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
+use App\Constants\Messages;
 
 class PurchaseOrderController extends Controller
 {
@@ -64,9 +65,9 @@ class PurchaseOrderController extends Controller
 
         try {
             PurchaseOrder::addPurchaseOrder($allData);
-            return redirect()->back()->with('success', 'Purchase Order berhasil ditambahkan.');
+            return redirect()->back()->with('success', Messages::PO_CREATED);
         } catch (\Exception $e) {
-            return redirect()->back()->with('error', 'Gagal menambahkan PO: ' . $e->getMessage());
+            return redirect()->back()->with('error', Messages::PO_CREATE_FAILED . $e->getMessage());
         }
     }
     public function getPOLength($poNumber, $orderDate) 

--- a/tests/Feature/Controllers/PurchaseOrderControllerTest.php
+++ b/tests/Feature/Controllers/PurchaseOrderControllerTest.php
@@ -1,0 +1,815 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use Tests\TestCase;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderDetail;
+use App\Models\Supplier;
+use App\Models\Branch;
+use App\Constants\Messages;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Carbon\Carbon;
+
+class PurchaseOrderControllerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // Setup database tables
+        $this->artisan('migrate:fresh');
+        
+        // Create supplier table if not exists (for testing)
+        if (!Schema::hasTable('supplier')) {
+            Schema::create('supplier', function ($table) {
+                $table->char('supplier_id', 6)->primary();
+                $table->string('company_name', 100);
+                $table->string('address', 100);
+                $table->string('phone_number', 30);
+                $table->string('bank_account', 100);
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Helper method to create branch using DB::table
+     */
+    private function createBranch($branchId = null)
+    {
+        $id = $branchId ?? $this->faker->numberBetween(1, 100);
+        
+        DB::table('branches')->insert([
+            'id' => $id,
+            'branch_name' => 'Cabang ' . $this->faker->city,
+            'branch_address' => $this->faker->address,
+            'branch_telephone' => $this->faker->phoneNumber,
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        
+        return $id;
+    }
+
+    /**
+     * Helper method to create supplier using DB::table
+     */
+    private function createSupplier($supplierId)
+    {
+        DB::table('supplier')->insert([
+            'supplier_id' => $supplierId,
+            'company_name' => $this->faker->company,
+            'address' => $this->faker->address,
+            'phone_number' => $this->faker->phoneNumber,
+            'bank_account' => $this->faker->bankAccountNumber,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Helper method to build valid PO request data
+     */
+    private function buildValidPOData($poNumber, $branchId, $supplierId, $items = [])
+    {
+        // Default: 1 item if not provided
+        if (empty($items)) {
+            $items = [
+                [
+                    'po_number' => $poNumber,
+                    'sku' => 'ITM001',
+                    'qty' => 10,
+                    'amount' => 100000,
+                ]
+            ];
+        }
+
+        // Calculate total
+        $total = array_sum(array_column($items, 'amount'));
+
+        // Build request data: items first, then header
+        $requestData = $items;
+        $requestData[] = [
+            'po_number' => $poNumber,
+            'branch_id' => $branchId,
+            'supplier_id' => $supplierId,
+            'total' => $total,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        return $requestData;
+    }
+
+    // ========== POSITIVE SCENARIOS ==========
+
+    /**
+     * TC-APO-01
+     * Test: Add PO with valid single item
+     * 
+     * Scenario: User submits PO with valid header and 1 item
+     * Expected: PO created successfully in database
+     */
+    public function test_add_po_with_valid_single_item()
+    {
+        // ARRANGE - Create test data
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP001');
+
+        $poData = $this->buildValidPOData('PO0001', $branchId, 'SUP001');
+
+        // ACT - Submit PO
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT - Verify success
+        $response->assertStatus(302);
+        $response->assertSessionHas('success', Messages::PO_CREATED);
+
+        // Verify database
+        $this->assertDatabaseHas('purchase_order', [
+            'po_number' => 'PO0001',
+            'supplier_id' => 'SUP001',
+            'branch_id' => $branchId,
+        ]);
+
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0001',
+            'product_id' => 'ITM001',
+            'quantity' => 10,
+            'amount' => 100000,
+        ]);
+    }
+
+    /**
+     * TC-APO-02
+     * Test: Add PO with multiple items (3 items)
+     * 
+     * Scenario: User submits PO with valid header and 3 items
+     * Expected: PO created with all 3 items in database
+     */
+    public function test_add_po_with_multiple_items()
+    {
+        // ARRANGE - Create test data
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP002');
+
+        $items = [
+            [
+                'po_number' => 'PO0002',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ],
+            [
+                'po_number' => 'PO0002',
+                'sku' => 'ITM002',
+                'qty' => 20,
+                'amount' => 200000,
+            ],
+            [
+                'po_number' => 'PO0002',
+                'sku' => 'ITM003',
+                'qty' => 10,
+                'amount' => 200000,
+            ],
+        ];
+
+        $poData = $this->buildValidPOData('PO0002', $branchId, 'SUP002', $items);
+
+        // ACT - Submit PO
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT - Verify success
+        $response->assertStatus(302);
+        $response->assertSessionHas('success', Messages::PO_CREATED);
+
+        // Verify header
+        $this->assertDatabaseHas('purchase_order', [
+            'po_number' => 'PO0002',
+            'supplier_id' => 'SUP002',
+            'total' => 500000,
+        ]);
+
+        // Verify all 3 items
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0002',
+            'product_id' => 'ITM001',
+        ]);
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0002',
+            'product_id' => 'ITM002',
+        ]);
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0002',
+            'product_id' => 'ITM003',
+        ]);
+
+        // Verify count
+        $detailCount = DB::table('purchase_order_detail')
+            ->where('po_number', 'PO0002')
+            ->count();
+        $this->assertEquals(3, $detailCount);
+    }
+
+    /**
+     * TC-APO-03
+     * Test: Add PO with minimum valid qty (qty=1)
+     * 
+     * Scenario: Test boundary value for minimum quantity
+     * Expected: PO created successfully with qty=1
+     */
+    public function test_add_po_with_minimum_valid_qty()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP003');
+
+        $items = [
+            [
+                'po_number' => 'PO0003',
+                'sku' => 'ITM001',
+                'qty' => 1, // Minimum valid
+                'amount' => 50000,
+            ]
+        ];
+
+        $poData = $this->buildValidPOData('PO0003', $branchId, 'SUP003', $items);
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0003',
+            'quantity' => 1,
+        ]);
+    }
+
+    /**
+     * TC-APO-04
+     * Test: Add PO with large qty (qty=9999)
+     * 
+     * Scenario: Test boundary value for large quantity
+     * Expected: PO created successfully with large qty
+     */
+    public function test_add_po_with_large_qty()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP004');
+
+        $items = [
+            [
+                'po_number' => 'PO0004',
+                'sku' => 'ITM001',
+                'qty' => 9999,
+                'amount' => 9999000,
+            ]
+        ];
+
+        $poData = $this->buildValidPOData('PO0004', $branchId, 'SUP004', $items);
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('purchase_order_detail', [
+            'po_number' => 'PO0004',
+            'quantity' => 9999,
+            'amount' => 9999000,
+        ]);
+    }
+
+    /**
+     * TC-APO-05
+     * Test: Add PO with today's order date
+     * 
+     * Scenario: Test with current date as order date
+     * Expected: PO created successfully with today's date
+     */
+    public function test_add_po_with_today_order_date()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP005');
+
+        $todayDate = Carbon::now()->format('Y-m-d');
+        
+        $items = [
+            [
+                'po_number' => 'PO0005',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0005',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP005',
+            'total' => 100000,
+            'order_date' => $todayDate,
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('purchase_order', [
+            'po_number' => 'PO0005',
+            'order_date' => $todayDate,
+        ]);
+    }
+
+    // ========== NEGATIVE SCENARIOS (Validation) ==========
+
+    /**
+     * TC-APO-06
+     * Test: Add PO with missing po_number in header
+     * 
+     * Scenario: Submit PO without po_number in header
+     * Expected: Validation error, no database insert
+     */
+    public function test_add_po_with_missing_po_number_in_header()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP006');
+
+        $items = [
+            [
+                'po_number' => 'PO0006',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        // Header WITHOUT po_number
+        $poData = $items;
+        $poData[] = [
+            // 'po_number' => 'PO0006', // MISSING
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP006',
+            'total' => 100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        // Verify NO database insert
+        $this->assertDatabaseMissing('purchase_order', [
+            'supplier_id' => 'SUP006',
+        ]);
+    }
+
+    /**
+     * TC-APO-07
+     * Test: Add PO with invalid branch_id (non-integer)
+     * 
+     * Scenario: Submit PO with string branch_id
+     * Expected: Validation error
+     */
+    public function test_add_po_with_invalid_branch_id()
+    {
+        // ARRANGE
+        $this->createSupplier('SUP007');
+
+        $items = [
+            [
+                'po_number' => 'PO0007',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0007',
+            'branch_id' => 'abc', // Invalid: string instead of integer
+            'supplier_id' => 'SUP007',
+            'total' => 100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0007',
+        ]);
+    }
+
+    /**
+     * TC-APO-08
+     * Test: Add PO with missing supplier_id
+     * 
+     * Scenario: Submit PO without supplier_id in header
+     * Expected: Validation error
+     */
+    public function test_add_po_with_missing_supplier_id()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+
+        $items = [
+            [
+                'po_number' => 'PO0008',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0008',
+            'branch_id' => $branchId,
+            // 'supplier_id' => 'SUP008', // MISSING
+            'total' => 100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0008',
+        ]);
+    }
+
+    /**
+     * TC-APO-09
+     * Test: Add PO with negative total
+     * 
+     * Scenario: Submit PO with negative total amount
+     * Expected: Validation error
+     */
+    public function test_add_po_with_negative_total()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP009');
+
+        $items = [
+            [
+                'po_number' => 'PO0009',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0009',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP009',
+            'total' => -50000, // Invalid: negative
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0009',
+        ]);
+    }
+
+    /**
+     * TC-APO-10
+     * Test: Add PO with invalid order_date format
+     * 
+     * Scenario: Submit PO with invalid date format
+     * Expected: Validation error
+     */
+    public function test_add_po_with_invalid_order_date_format()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP010');
+
+        $items = [
+            [
+                'po_number' => 'PO0010',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0010',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP010',
+            'total' => 100000,
+            'order_date' => 'invalid-date', // Invalid format
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0010',
+        ]);
+    }
+
+    /**
+     * TC-APO-11
+     * Test: Add PO with missing sku in item
+     * 
+     * Scenario: Submit PO item without sku
+     * Expected: Validation error
+     */
+    public function test_add_po_with_missing_sku_in_item()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP011');
+
+        $items = [
+            [
+                'po_number' => 'PO0011',
+                // 'sku' => 'ITM001', // MISSING
+                'qty' => 10,
+                'amount' => 100000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0011',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP011',
+            'total' => 100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0011',
+        ]);
+    }
+
+    /**
+     * TC-APO-12
+     * Test: Add PO with qty = 0 (below minimum)
+     * 
+     * Scenario: Submit PO item with qty = 0
+     * Expected: Validation error (min:1)
+     */
+    public function test_add_po_with_qty_zero()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP012');
+
+        $items = [
+            [
+                'po_number' => 'PO0012',
+                'sku' => 'ITM001',
+                'qty' => 0, // Invalid: below minimum
+                'amount' => 0,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0012',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP012',
+            'total' => 0,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0012',
+        ]);
+    }
+
+    /**
+     * TC-APO-13
+     * Test: Add PO with negative qty
+     * 
+     * Scenario: Submit PO item with negative quantity
+     * Expected: Validation error
+     */
+    public function test_add_po_with_negative_qty()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP013');
+
+        $items = [
+            [
+                'po_number' => 'PO0013',
+                'sku' => 'ITM001',
+                'qty' => -5, // Invalid: negative
+                'amount' => -50000,
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0013',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP013',
+            'total' => -50000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0013',
+        ]);
+    }
+
+    /**
+     * TC-APO-14
+     * Test: Add PO with negative amount
+     * 
+     * Scenario: Submit PO item with negative amount
+     * Expected: Validation error
+     */
+    public function test_add_po_with_negative_amount()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP014');
+
+        $items = [
+            [
+                'po_number' => 'PO0014',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                'amount' => -100000, // Invalid: negative
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0014',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP014',
+            'total' => -100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0014',
+        ]);
+    }
+
+    /**
+     * TC-APO-15
+     * Test: Add PO with missing amount in item
+     * 
+     * Scenario: Submit PO item without amount
+     * Expected: Validation error
+     */
+    public function test_add_po_with_missing_amount_in_item()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP015');
+
+        $items = [
+            [
+                'po_number' => 'PO0015',
+                'sku' => 'ITM001',
+                'qty' => 10,
+                // 'amount' => 100000, // MISSING
+            ]
+        ];
+
+        $poData = $items;
+        $poData[] = [
+            'po_number' => 'PO0015',
+            'branch_id' => $branchId,
+            'supplier_id' => 'SUP015',
+            'total' => 100000,
+            'order_date' => Carbon::now()->format('Y-m-d'),
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors();
+
+        $this->assertDatabaseMissing('purchase_order', [
+            'po_number' => 'PO0015',
+        ]);
+    }
+
+    // ========== EDGE CASES & ERROR HANDLING ==========
+
+    /**
+     * TC-APO-16
+     * Test: Empty items array
+     * 
+     * Scenario: Submit PO with empty items array (only header, no items)
+     * Expected: Should succeed but no items inserted (only header)
+     * 
+     * Note: Controller doesn't validate empty items, it just processes what's given
+     */
+    public function test_add_po_with_empty_items_array()
+    {
+        // ARRANGE
+        $branchId = $this->createBranch(1);
+        $this->createSupplier('SUP016');
+
+        // Build request manually without items (only header)
+        $poData = [
+            [
+                'po_number' => 'PO0016',
+                'branch_id' => $branchId,
+                'supplier_id' => 'SUP016',
+                'total' => 0,
+                'order_date' => Carbon::now()->format('Y-m-d'),
+            ]
+        ];
+
+        // ACT
+        $response = $this->post('/purchase_orders/add', $poData);
+
+        // ASSERT
+        $response->assertStatus(302);
+        $response->assertSessionHas('success');
+        
+        // Header should be in database
+        $this->assertDatabaseHas('purchase_order', ['po_number' => 'PO0016']);
+        
+        // But NO detail records
+        $detailCount = DB::table('purchase_order_detail')->where('po_number', 'PO0016')->count();
+        $this->assertEquals(0, $detailCount, 'Should have no detail records for empty items');
+    }
+}


### PR DESCRIPTION
This pull request updates how success and error messages are handled when creating a purchase order, centralizing message definitions for consistency and maintainability. The main changes include introducing new message constants, updating the controller to use themm and adds comprehensive unit tests for the addPurchaseOrder method in PurchaseOrderController.

**Centralization and standardization of messages:**

* Added new constants for purchase order creation success and failure messages to the `Messages` class in `app/Constants/Messages.php`.
* Updated the `PurchaseOrderController` to use the new message constants for purchase order creation feedback, replacing hardcoded strings.

**Codebase consistency:**

* Imported the `Messages` class in `PurchaseOrderController.php` to enable the use of centralized message constants.

**Test Result.**

<img width="931" height="501" alt="Cuplikan layar 2025-12-01 073008" src="https://github.com/user-attachments/assets/03773cc8-243d-4b3b-8646-532dfbf2458d" />
