### PR TITLE
177_Tambahkan pengujian unit untuk fungsi CountStatusPurchaseOrder

### DIFF
--- a/tests/Unit/Models/CountStatusPOTest.php
+++ b/tests/Unit/Models/CountStatusPOTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use Tests\TestCase;
+use App\Models\PurchaseOrder;
+use App\Enums\POStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CountStatusPOTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_count_status_po_with_no_purchase_orders()
+    {
+        $result = PurchaseOrder::countStatusPO();
+        $this->assertEmpty($result);
+    }
+
+    public function test_count_status_po_with_single_purchase_order()
+    {
+        PurchaseOrder::create([
+            'po_number' => 'PO001',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 1000,
+            'status' => POStatus::Draft->value,
+        ]);
+
+        $result = PurchaseOrder::countStatusPO();
+        $draft = collect($result)->firstWhere('status', POStatus::Draft->value);
+
+        $this->assertEquals(1, $draft->total);
+    }
+
+    public function test_count_status_po_with_multiple_purchase_orders_same_status()
+    {
+        PurchaseOrder::create([
+            'po_number' => 'PO001',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 1000,
+            'status' => POStatus::Approved->value,
+        ]);
+
+        PurchaseOrder::create([
+            'po_number' => 'PO002',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 2000,
+            'status' => POStatus::Approved->value,
+        ]);
+
+        $result = PurchaseOrder::countStatusPO();
+        $approved = collect($result)->firstWhere('status', POStatus::Approved->value);
+
+        $this->assertEquals(2, $approved->total);
+    }
+
+    public function test_count_status_po_with_multiple_purchase_orders_different_statuses()
+    {
+        PurchaseOrder::create([
+            'po_number' => 'PO001',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 1000,
+            'status' => POStatus::Draft->value,
+        ]);
+
+        PurchaseOrder::create([
+            'po_number' => 'PO002',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 2000,
+            'status' => POStatus::Submitted->value,
+        ]);
+
+        PurchaseOrder::create([
+            'po_number' => 'PO003',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 3000,
+            'status' => POStatus::Approved->value,
+        ]);
+
+        PurchaseOrder::create([
+            'po_number' => 'PO004',
+            'supplier_id' => 1,
+            'branch_id' => 1,
+            'order_date' => now(),
+            'total' => 4000,
+            'status' => POStatus::Approved->value,
+        ]);
+
+        $result = PurchaseOrder::countStatusPO();
+
+        $this->assertEquals(1, collect($result)->firstWhere('status', POStatus::Draft->value)->total);
+        $this->assertEquals(1, collect($result)->firstWhere('status', POStatus::Submitted->value)->total);
+        $this->assertEquals(2, collect($result)->firstWhere('status', POStatus::Approved->value)->total);
+    }
+
+    public function test_count_status_po_with_all_statuses()
+    {
+        $statuses = [
+            POStatus::Draft,
+            POStatus::Submitted,
+            POStatus::InReview,
+            POStatus::Revised,
+            POStatus::Approved,
+            POStatus::Rejected,
+            POStatus::Cancelled,
+            POStatus::Closed,
+            POStatus::PL,
+            POStatus::FD,
+        ];
+
+        foreach ($statuses as $index => $status) {
+            PurchaseOrder::create([
+                'po_number' => 'PO' . str_pad($index + 1, 3, '0', STR_PAD_LEFT),
+                'supplier_id' => 1,
+                'branch_id' => 1,
+                'order_date' => now(),
+                'total' => 1000 * ($index + 1),
+                'status' => $status->value,
+            ]);
+        }
+
+        $result = PurchaseOrder::countStatusPO();
+
+        foreach ($statuses as $status) {
+            $item = collect($result)->firstWhere('status', $status->value);
+            $this->assertEquals(1, $item->total);
+        }
+    }
+}


### PR DESCRIPTION
### Dokumentasi Test CountStatusPO

Test ini memeriksa apakah fungsi `countStatusPO()` dapat menghitung jumlah Purchase Order berdasarkan status dengan benar.

Skenario yang diuji:
* Tidak ada data PO → hasil harus kosong
* Satu PO dengan status tertentu → jumlah status tersebut = 1
* Banyak PO dengan status yang sama → jumlah status sesuai total data
* Banyak PO dengan status berbeda-beda → masing-masing status terhitung dengan benar
* Semua status POStatus digunakan → setiap status terhitung 1

<img width="1235" height="347" alt="image" src="https://github.com/user-attachments/assets/d298d1e1-0283-4b86-8d6a-62b7799cb69f" />

