### PR TITLE
add unit test for deleteSupplierByID in SupplierController

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -230,6 +230,8 @@ Route::get('/supplier/detail/{id}', [SupplierController::class, 'getSupplierById
 Route::get('/suppliers/search', [SupplierController::class, 'searchSuppliers']);
 Route::delete('/supplier/pic/delete/{id}', [SupplierPIController::class, 'delete'])->name('supplier.pic.delete');
 Route::get('/supplier/list', [SupplierController::class, 'listSuppliers'])->name('supplier.list');
+Route::delete('/supplier/delete/{id}', [SupplierController::class, 'deleteSupplierByID'])->name('supplier.delete');
+
 
 Route::get('/supplier/material/{id}', [SupplierMaterialController::class, 'getSupplierMaterialById'])->name('supplier.material.detail');
 Route::get('/suppliers/search', [SupplierController::class, 'searchSuppliers']);


### PR DESCRIPTION
- Menambahkan fungsi test untuk deleteSupplierByID di SupplierController

- Menambahkan route **DELETE /supplier/delete/{id}** untuk mengekspos method controller deleteSupplierByID yang sudah ada. Ini memperbaiki error 404 saat testing dan mengaktifkan fitur hapus.



<img width="982" height="285" alt="Cuplikan layar 2025-12-22 191631" src="https://github.com/user-attachments/assets/8cc16b56-9255-4485-9c2e-7ffb76c05f2c" />
