### PR TITLE
Feat: add unit testing MerkModel method deleteMerkByID

### DIFF
--- a/tests/Unit/Models/MerkTest.php
+++ b/tests/Unit/Models/MerkTest.php
@@ -530,13 +530,13 @@ class MerkTest extends TestCase
     // ========================================================================
 
     /**
-     * Test deleting an unused merk successfully
+     * Test deleting a merk successfully
      * Corresponds to TC-MK-19 from PRD (Happy Path)
      * @test
      */
-    public function test_it_can_delete_unused_merk_successfully()
+    public function test_it_can_delete_merk_successfully()
     {
-        // Arrange - Create a merk that has no relationships
+        // Arrange - Create a merk record
         $merk = Merk::factory()->create([
             MerkColumns::MERK => 'Test Brand',
             MerkColumns::IS_ACTIVE => true

--- a/tests/Unit/Models/MerkTest.php
+++ b/tests/Unit/Models/MerkTest.php
@@ -525,7 +525,9 @@ class MerkTest extends TestCase
     }
 
     // ========================================================================
-    // TEST UNTUK DELETE OPERATIONS
+    // TEST UNTUK DELETE OPERATIONS (Laravel Eloquent delete() on Merk model)
+    // These tests cover Laravel's built-in Eloquent delete() method on Merk instances,
+    // not a custom deleteMerkByID() method.
     // Based on PRD Test Cases TC-MK-19 to TC-MK-23
     // ========================================================================
 


### PR DESCRIPTION
This pull request adds a comprehensive suite of tests for delete operations on the `Merk` model in `MerkTest.php`. The new tests cover both standard and edge cases for deleting merks, ensuring correct behavior, data integrity, and proper handling of invalid or non-existent IDs.

**Delete Operation Test Coverage:**

* Added tests for successful deletion of unused, active, and inactive merks, verifying database state and count after each operation.
* Included tests for deleting multiple merks in sequence and ensuring the count decreases correctly.

**Edge and Negative Cases:**

* Added tests for attempting to delete non-existent merks, already deleted merks, and merks with invalid ID types (e.g., string or negative ID), ensuring the system returns `null` and maintains stability.
* Verified that deleting one merk does not affect others, maintaining data integrity for remaining records.

**Screenshot**
<img width="849" height="387" alt="image" src="https://github.com/user-attachments/assets/1b947835-a9c0-4812-9559-9c98f2c88608" />
