### PR TITLE
Menyambungkan form input Goods Receipt Note ke database

### DIFF
--- a/app/Http/Controllers/GoodsReceiptNoteController.php
+++ b/app/Http/Controllers/GoodsReceiptNoteController.php
@@ -79,4 +79,28 @@ class GoodsReceiptNoteController extends Controller
             'data' => $grn
         ], 200);
     }
+
+    public function storeFromForm(Request $request)
+    {
+        $validated = $request->validate([
+            'po_number' => 'required|string|exists:purchase_order,po_number',
+            'items' => 'required|array|min:1',
+            'items.*.product_id' => 'required|string',
+            'items.*.delivery_date' => 'required|date',
+            'items.*.delivered_quantity' => 'required|integer|min:0',
+            'items.*.comments' => 'nullable|string',
+        ]);
+
+        foreach ($validated['items'] as $item) {
+            GoodsReceiptNote::addGoodsReceiptNote([
+                'po_number' => $validated['po_number'],
+                'product_id' => $item['product_id'],
+                'delivery_date' => $item['delivery_date'],
+                'delivered_quantity' => $item['delivered_quantity'],
+                'comments' => $item['comments'] ?? null,
+            ]);
+        }
+
+        return redirect()->route('purchase.orders')->with('success', 'Goods Receipt Note berhasil disimpan.');
+    }
 }

--- a/app/Models/PurchaseOrderDetail.php
+++ b/app/Models/PurchaseOrderDetail.php
@@ -11,4 +11,9 @@ class PurchaseOrderDetail extends Model
     
     protected $table = 'purchase_order_detail';
     protected $fillable = ['po_number','product_id','base_price','quantity','amount','received_days','created_at','updated_at'];
+
+    public function product()
+    {
+        return $this->belongsTo(Item::class, 'product_id', 'product_id');
+    }
 }

--- a/resources/views/goods_receipt_note/add.blade.php
+++ b/resources/views/goods_receipt_note/add.blade.php
@@ -23,7 +23,8 @@
           <label for="po_number">PO Number</label>
           <input type="text" class="form-control" id="po_number" value="POO0002" readonly>
         </div>
-        <form>
+        <form action="{{ route('goods_receipt_note.store') }}" method="POST">
+          @csrf
           <div class="form-group mb-3">
             <label for="branch">Branch</label>
             <input type="text" class="form-control" id="branch" value="Yogyakarta" readonly>

--- a/routes/web.php
+++ b/routes/web.php
@@ -317,6 +317,7 @@ Route::get('/bom/detail/{id}', function ($id) {
 
 // Goods Receipt Notes
 Route::post('/goods-receipt-note', [GoodsReceiptNoteController::class, 'addGoodsReceiptNote']);
+Route::post('/goods_receipt_note/store', [GoodsReceiptNoteController::class, 'storeFromForm'])->name('goods_receipt_note.store');
 
 Route::put('/goods-receipt-note/{po_number}', [GoodsReceiptNoteController::class, 'updateGoodsReceiptNote']);
 


### PR DESCRIPTION
Form input Goods Receipt Note sebelumnya belum tersambung ke database (belum ada action dan token CSRF). 

PR ini menambahkan:
- Action dan @csrf pada form di add.blade.php
- Method storeFromForm() di GoodsReceiptNoteController untuk menyimpan data ke tabel goods_receipt_note
- Route baru goods_receipt_note.store
- Relasi product() di PurchaseOrderDetail model