### PR TITLE
(Usulan) tampilkan product name dan description di list table

### DIFF
--- a/resources/views/product/list.blade.php
+++ b/resources/views/product/list.blade.php
@@ -75,7 +75,7 @@ use App\Helpers\EncryptionHelper;
                         <td>{{ $product->name }}</td>
                         <td>{{ $product->type->label() }}</td>
                         <td>{{ $product->categoryRelation ? $product->categoryRelation->category : 'Tidak Ada' }}</td>
-                        <td>{{ $product->product_description }}</td>
+                        <td>{{ $product->description }}</td>
                         <td>{{ $product->items_count }}</td>
                         <td>{{ $product->created_at }}</td>
                         <td>{{ $product->updated_at }}</td>

--- a/resources/views/product/list.blade.php
+++ b/resources/views/product/list.blade.php
@@ -72,7 +72,7 @@ use App\Helpers\EncryptionHelper;
                                 {{ $product->product_id }}
                             </a>
                         </td>
-                        <td>{{ $product->product_name }}</td>
+                        <td>{{ $product->name }}</td>
                         <td>{{ $product->type->label() }}</td>
                         <td>{{ $product->categoryRelation ? $product->categoryRelation->category : 'Tidak Ada' }}</td>
                         <td>{{ $product->product_description }}</td>


### PR DESCRIPTION
## Deskripsi
Perbaikan tampilan kolom product_name dan product_description yang sebelumnya kosong di halaman list produk.

### Masalah
Kolom product_name dan product_description di table list produk tidak menampilkan data, padahal di halaman detail data sudah ada.

### Penyebab
Penggunaan attribute yang salah di view:
- View menggunakan: `$product->product_name` (tidak ada di model)
- View menggunakan: `$product->product_description` (tidak ada di model)
- Database kolom yang benar: `name` dan `description`

### Solusi
Mengubah attribute yang digunakan di view sesuai dengan nama kolom di database:
- Ubah dari `$product->product_name` menjadi `$product->name`
- Ubah dari `$product->product_description` menjadi `$product->description`

### HASIL
<img width="1917" height="690" alt="Cuplikan layar 2026-07-07 121100" src="https://github.com/user-attachments/assets/94a60193-166c-468c-a16e-e113af648595" />


### SEBELUM 
<img width="1920" height="900" alt="Screenshot (1661)" src="https://github.com/user-attachments/assets/d5027dcb-7d09-4dbc-833b-87997f3a125a" />
