### PR TITLE
(USULAN) Menambahkan fitur cetak PDF per Purchase Order

### DIFF
--- a/app/Http/Controllers/PurchaseOrderController.php
+++ b/app/Http/Controllers/PurchaseOrderController.php
@@ -147,4 +147,22 @@ class PurchaseOrderController extends Controller
             return response()->json(['error' => 'Server gagal mengirim email: ' . $e->getMessage()], 500);
         }
     }
+    public function printPurchaseOrderToPDF($po_number)
+    {
+        $purchaseOrder = PurchaseOrder::with('supplier', 'details')
+            ->where('po_number', $po_number)
+            ->first();
+
+        if (!$purchaseOrder) {
+            abort(404, 'Purchase Order tidak ditemukan.');
+        }
+
+        $data = [
+            'purchaseOrder' => $purchaseOrder,
+            'generatedAt'   => Carbon::now()->format('d-m-Y H:i:s'),
+        ];
+
+        $pdf = Pdf::loadView('purchase_orders.pdf_single', $data);
+        return $pdf->stream('PO_' . $po_number . '.pdf');
+    }
 }

--- a/resources/views/purchase_orders/pdf_single.blade.php
+++ b/resources/views/purchase_orders/pdf_single.blade.php
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Purchase Order - {{ $purchaseOrder->po_number }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            line-height: 1.5;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+            border-bottom: 2px solid #000;
+            padding-bottom: 10px;
+        }
+        h1 {
+            font-size: 18px;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+        .info-table {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+        .info-table td {
+            padding: 3px 0;
+        }
+        table.data-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        table.data-table th,
+        table.data-table td {
+            border: 1px solid #ddd;
+            padding: 6px;
+            font-size: 11px;
+        }
+        table.data-table th {
+            background-color: #f2f2f2;
+            text-align: left;
+        }
+        .total-row td {
+            font-weight: bold;
+            background-color: #f9f9f9;
+        }
+        .signature {
+            margin-top: 60px;
+            width: 100%;
+        }
+        .signature td {
+            text-align: center;
+            width: 33%;
+            vertical-align: top;
+        }
+        .signature .line {
+            margin-top: 50px;
+            border-top: 1px solid #000;
+            width: 80%;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .badge-approved { color: green; font-weight: bold; }
+        .badge-pending  { color: orange; font-weight: bold; }
+        .badge-other    { color: gray; font-weight: bold; }
+    </style>
+</head>
+<body>
+
+    <div class="header">
+        <h1>PURCHASE ORDER</h1>
+        <p>{{ config('app.name', 'ERP RPL UAD') }}</p>
+    </div>
+
+    <table class="info-table">
+        <tr>
+            <td width="150">No. PO</td>
+            <td width="10">:</td>
+            <td><strong>{{ $purchaseOrder->po_number }}</strong></td>
+            <td width="150">Tanggal Order</td>
+            <td width="10">:</td>
+            <td>{{ \Carbon\Carbon::parse($purchaseOrder->order_date)->format('d-m-Y') }}</td>
+        </tr>
+        <tr>
+            <td>Supplier</td>
+            <td>:</td>
+            <td>{{ $purchaseOrder->supplier->company_name ?? '-' }}</td>
+            <td>Status</td>
+            <td>:</td>
+            <td>
+                @if($purchaseOrder->status === 'Approved')
+                    <span class="badge-approved">{{ $purchaseOrder->status }}</span>
+                @elseif($purchaseOrder->status === 'Pending')
+                    <span class="badge-pending">{{ $purchaseOrder->status }}</span>
+                @else
+                    <span class="badge-other">{{ $purchaseOrder->status }}</span>
+                @endif
+            </td>
+        </tr>
+        <tr>
+            <td>ID Supplier</td>
+            <td>:</td>
+            <td>{{ $purchaseOrder->supplier_id }}</td>
+            <td>Tanggal Cetak</td>
+            <td>:</td>
+            <td>{{ $generatedAt }}</td>
+        </tr>
+    </table>
+
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>No.</th>
+                <th>Product ID</th>
+                <th>Quantity</th>
+                <th>Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            @php $grandTotal = 0; @endphp
+            @forelse($purchaseOrder->details as $index => $detail)
+                @php $grandTotal += $detail->amount; @endphp
+                <tr>
+                    <td>{{ $index + 1 }}</td>
+                    <td>{{ $detail->product_id }}</td>
+                    <td align="right">{{ number_format($detail->quantity, 0, ',', '.') }}</td>
+                    <td align="right">Rp {{ number_format($detail->amount, 0, ',', '.') }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" style="text-align:center; font-style:italic;">
+                        Tidak ada item pada Purchase Order ini.
+                    </td>
+                </tr>
+            @endforelse
+        </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="3" align="right">Grand Total</td>
+                <td align="right">Rp {{ number_format($grandTotal, 0, ',', '.') }}</td>
+            </tr>
+        </tfoot>
+    </table>
+
+    <table class="signature">
+        <tr>
+            <td>
+                Dibuat oleh,
+                <div class="line"></div>
+                ( Purchasing )
+            </td>
+            <td>
+                Disetujui oleh,
+                <div class="line"></div>
+                ( Manager )
+            </td>
+            <td>
+                Diterima oleh,
+                <div class="line"></div>
+                ( Supplier )
+            </td>
+        </tr>
+    </table>
+
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -196,6 +196,7 @@ Route::get('/po-length/{po_number}/{order_date}', [PurchaseOrderController::clas
     ->name('purchase_orders.length');
 Route::get('/purchase-orders/report', [PurchaseOrderController::class, 'showReportForm'])->name('purchase_orders.report_form');
 Route::post('/purchase-orders/pdf', [PurchaseOrderController::class, 'generatePurchaseOrderPDF'])->name('purchase_orders.pdf');
+Route::get('/purchase-orders/{po_number}/pdf', [PurchaseOrderController::class, 'printPurchaseOrderToPDF'])->name('purchase_orders.print_pdf');
 Route::get('/purchase_orders', [PurchaseOrderController::class, 'getPurchaseOrder'])->name('purchase.orders');
 Route::get('/purchase_orders/{id}', [PurchaseOrderController::class, 'getPurchaseOrderByID']);
 Route::get('/purchase-order/status/{status}', [PurchaseOrderController::class, 'getPurchaseOrderByStatus']);


### PR DESCRIPTION
Sebelumnya belum ada fitur untuk mencetak satu Purchase Order tertentu ke format PDF.

PR ini menambahkan:
- Method printPurchaseOrderToPDF($po_number) di PurchaseOrderController
- Route baru GET /purchase-orders/{po_number}/pdf
- Template PDF baru pdf_single.blade.php yang menampilkan info PO, supplier, daftar item, grand total, dan kolom tanda tangan

Cara test: buka /purchase-orders/{po_number}/pdf di browser, PDF langsung terbuka di tab baru.