### PR TITLE
(USULAN) Menambahkan method deleteBillOfMaterial pada model BillOfMaterial

### DIFF
--- a/app/Http/Controllers/BillOfMaterialController.php
+++ b/app/Http/Controllers/BillOfMaterialController.php
@@ -33,7 +33,7 @@ class BillOfMaterialController extends Controller
     // Fungsi untuk menghapus Bill of Material berdasarkan id
     public function deleteBillOfMaterial($id)
     {
-        $deleted = BillOfMaterial::deleteBom($id);
+        $deleted = BillOfMaterial::deleteBillOfMaterial($id);
 
         if ($deleted) {
             return response()->json(['message' => 'Bill of Material deleted successfully.'], 200);

--- a/app/Models/BillOfMaterial.php
+++ b/app/Models/BillOfMaterial.php
@@ -34,7 +34,16 @@ class BillOfMaterial extends Model
         }
         return self::create($data);
     }
+    public static function deleteBillOfMaterial($id)
+    {
+        $bom = self::find($id);
 
+        if (!$bom) {
+            return false;
+        }
+
+        return $bom->delete();
+    }
     public static function getBillOfMaterialById($id)
     {
         return self::where('bom_id', $id)->get();


### PR DESCRIPTION
Method deleteBillOfMaterial($id) belum ada di model, sementara controller sudah memanggil BillOfMaterial::deleteBom($id) yang tidak ada sehingga akan error saat tombol delete diklik.

PR ini menambahkan:
- Method deleteBillOfMaterial($id) di BillOfMaterialModel yang mencari BOM berdasarkan ID lalu menghapusnya
- Memperbaiki pemanggilan di BillOfMaterialController dari deleteBom() menjadi deleteBillOfMaterial()