### PR TITLE
(USULAN) Menambahkan form edit Assortment Production yang sebelumnya belum berfungsi

### DIFF
--- a/resources/views/assortment_production/list.blade.php
+++ b/resources/views/assortment_production/list.blade.php
@@ -168,7 +168,7 @@
               <td>{{ $produksi->created_at }}</td>
               <td>{{ $produksi->updated_at }}</td>
               <td>
-                <a href="#" class="btn btn-sm btn-primary">Edit</a>
+                <button type="button" class="btn btn-sm btn-primary" onclick="editProduksi({{ $produksi->id }})">Edit</button>
                 <form action="#" method="POST" style="display: inline;">
                   @csrf
                   <button type="submit" class="btn btn-sm btn-danger">Delete</button>
@@ -192,7 +192,67 @@
 </div>
 @endsection
 
-@push('scripts')
+{{-- Modal Edit Produksi (form filled) --}}
+<div class="modal fade" id="editProduksiModal" tabindex="-1" aria-labelledby="editProduksiModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editProduksiModalLabel">Edit Produksi</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="editProduksiForm">
+          <input type="hidden" id="edit_produksi_id">
+          <div class="row g-3 mb-3">
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">Production Number</label>
+              <input type="text" class="form-control" id="edit_production_number" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">SKU</label>
+              <input type="text" class="form-control" id="edit_sku" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">Branch ID</label>
+              <input type="number" class="form-control" id="edit_branch_id" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">RM Warehouse ID</label>
+              <input type="number" class="form-control" id="edit_rm_whouse_id" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">FG Warehouse ID</label>
+              <input type="number" class="form-control" id="edit_fg_whouse_id" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">Production Date</label>
+              <input type="text" class="form-control" id="edit_production_date" required>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">Finished Date</label>
+              <input type="date" class="form-control" id="edit_finished_date">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label fw-semibold">In Production</label>
+              <select class="form-select" id="edit_in_production">
+                <option value="1">YES</option>
+                <option value="0">NO</option>
+              </select>
+            </div>
+            <div class="col-md-12">
+              <label class="form-label fw-semibold">Description</label>
+              <input type="text" class="form-control" id="edit_description">
+            </div>
+          </div>
+          <div class="d-flex justify-content-end">
+            <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Batal</button>
+            <button type="submit" class="btn btn-primary">Simpan Perubahan</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   const form = document.getElementById('addMaterialForm');
@@ -216,6 +276,59 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   }
+});
+
+// Mengambil data produksi yang sudah ada, lalu mengisi form edit (form filled)
+function editProduksi(id) {
+  fetch(`/assortment_production/detail/${id}`)
+    .then(res => res.json())
+    .then(data => {
+      document.getElementById('edit_produksi_id').value = data.id;
+      document.getElementById('edit_production_number').value = data.production_number;
+      document.getElementById('edit_sku').value = data.sku;
+      document.getElementById('edit_branch_id').value = data.branch_id;
+      document.getElementById('edit_rm_whouse_id').value = data.rm_whouse_id;
+      document.getElementById('edit_fg_whouse_id').value = data.fg_whouse_id;
+      document.getElementById('edit_production_date').value = data.production_date;
+      document.getElementById('edit_finished_date').value = data.finished_date ?? '';
+      document.getElementById('edit_in_production').value = data.in_production;
+      document.getElementById('edit_description').value = data.description ?? '';
+
+      var modal = new bootstrap.Modal(document.getElementById('editProduksiModal'));
+      modal.show();
+    })
+    .catch(err => alert('Gagal mengambil data produksi'));
+}
+
+// Mengirim perubahan ke endpoint update yang sudah ada
+document.getElementById('editProduksiForm').addEventListener('submit', function (e) {
+  e.preventDefault();
+  const id = document.getElementById('edit_produksi_id').value;
+
+  fetch(`/assortment_production/update/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+    },
+    body: JSON.stringify({
+      production_number: document.getElementById('edit_production_number').value,
+      sku:               document.getElementById('edit_sku').value,
+      branch_id:         document.getElementById('edit_branch_id').value,
+      rm_whouse_id:      document.getElementById('edit_rm_whouse_id').value,
+      fg_whouse_id:      document.getElementById('edit_fg_whouse_id').value,
+      production_date:   document.getElementById('edit_production_date').value,
+      finished_date:     document.getElementById('edit_finished_date').value || null,
+      in_production:     document.getElementById('edit_in_production').value,
+      description:       document.getElementById('edit_description').value,
+    }),
+  })
+    .then(res => res.json())
+    .then(() => {
+      alert('Data produksi berhasil diperbarui.');
+      location.reload();
+    })
+    .catch(err => alert('Gagal menyimpan perubahan.'));
 });
 </script>
 @endpush


### PR DESCRIPTION
Tombol "Edit" pada halaman daftar Assortment Production sebelumnya hanya href="#" sehingga tidak berfungsi saat diklik.

PR ini menambahkan:
- Modal form edit produksi yang otomatis terisi data saat tombol Edit diklik (form filled)
- Fungsi JS editProduksi(id) untuk mengambil data via fetch ke endpoint yang sudah ada (GET /assortment_production/detail/{id})
- Handler submit yang mengirim perubahan ke endpoint update yang sudah ada (PUT /assortment_production/update/{id})

Cara test: buka halaman /assortment_production, klik tombol Edit pada salah satu baris, form akan terbuka dengan data produksi terisi otomatis.