### PR TITLE
Tambah fondasi tabel users dan role

### DIFF
--- a/app/Constants/Messages.php
+++ b/app/Constants/Messages.php
@@ -83,6 +83,14 @@ class Messages
     public const PO_DELETED = 'Purchase Order berhasil dihapus.';
     public const PO_DELETE_FAILED = 'Gagal menghapus Purchase Order: ';
 
+    // User messages
+    public const USER_NOT_FOUND = 'User tidak ditemukan';
+    public const USER_CREATED = 'User berhasil ditambahkan!';
+    public const USER_UPDATED = 'User berhasil diupdate!';
+    public const USER_DELETED = 'User berhasil dihapus!';
+    public const USER_DELETE_FAILED = 'Gagal menghapus user!';
+    public const USER_EMAIL_EXISTS = 'Email sudah digunakan, silakan gunakan email lain.';
+
     // General
     public const ACTION_FAILED = 'Aksi gagal dilakukan!';
 }

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case ADMIN = 'admin';
+    case STAFF = 'staff';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::ADMIN => 'Admin',
+            self::STAFF => 'Staff',
+        };
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Enums\UserRole;
 
 class User extends Authenticatable
 {
@@ -21,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -43,6 +45,49 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === UserRole::ADMIN;
+    }
+
+    public static function getAllUsers($search = null)
+    {
+        $query = self::query();
+
+        if ($search) {
+            $query->where('name', 'LIKE', "%{$search}%")
+                  ->orWhere('email', 'LIKE', "%{$search}%");
+        }
+
+        return $query->orderBy('created_at', 'desc')->paginate(10);
+    }
+
+    public static function addUser(array $data)
+    {
+        return self::create($data);
+    }
+
+    public static function updateUser($id, array $data)
+    {
+        $user = self::find($id);
+        if (!$user) {
+            return false;
+        }
+
+        if (empty($data['password'])) {
+            unset($data['password']);
+        }
+
+        $user->update($data);
+        return true;
+    }
+
+    public static function deleteUser($id)
+    {
+        return self::where('id', $id)->delete();
     }
 }

--- a/database/migrations/2026_07_06_000001_create_users_table.php
+++ b/database/migrations/2026_07_06_000001_create_users_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->string('role')->default('staff');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            UserSeeder::class,
             MerkSeeder::class,
             MeasurementUnitSeeder::class,
             WarehouseSeeder::class,

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use App\Enums\UserRole;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::firstOrCreate(
+            ['email' => 'admin@erp.test'],
+            [
+                'name' => 'Admin ERP',
+                'password' => 'password',
+                'role' => UserRole::ADMIN,
+            ]
+        );
+
+        User::firstOrCreate(
+            ['email' => 'staff@erp.test'],
+            [
+                'name' => 'Staff ERP',
+                'password' => 'password',
+                'role' => UserRole::STAFF,
+            ]
+        );
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Models\User;
+use App\Enums\UserRole;
+
+class UserTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_add_user_hashes_password_and_casts_role()
+    {
+        $user = User::addUser([
+            'name' => 'Test User',
+            'email' => 'unittest.user@erp.test',
+            'password' => 'secret123',
+            'role' => UserRole::ADMIN->value,
+        ]);
+
+        $this->assertNotEquals('secret123', $user->getRawOriginal('password'));
+        $this->assertTrue($user->isAdmin());
+        $this->assertInstanceOf(UserRole::class, $user->role);
+    }
+
+    public function test_get_all_users_filters_by_search()
+    {
+        User::addUser([
+            'name' => 'Findable Person',
+            'email' => 'findable.person@erp.test',
+            'password' => 'secret123',
+            'role' => UserRole::STAFF->value,
+        ]);
+
+        $results = User::getAllUsers('Findable Person');
+
+        $this->assertGreaterThanOrEqual(1, $results->total());
+        $this->assertEquals('Findable Person', $results->first()->name);
+    }
+
+    public function test_update_user_without_password_keeps_old_password()
+    {
+        $user = User::addUser([
+            'name' => 'Original Name',
+            'email' => 'update.user@erp.test',
+            'password' => 'secret123',
+            'role' => UserRole::STAFF->value,
+        ]);
+        $originalHash = $user->getRawOriginal('password');
+
+        User::updateUser($user->id, [
+            'name' => 'Updated Name',
+            'email' => 'update.user@erp.test',
+            'password' => '',
+            'role' => UserRole::ADMIN->value,
+        ]);
+
+        $fresh = $user->fresh();
+        $this->assertEquals('Updated Name', $fresh->name);
+        $this->assertEquals($originalHash, $fresh->getRawOriginal('password'));
+        $this->assertTrue($fresh->isAdmin());
+    }
+
+    public function test_delete_user_removes_record()
+    {
+        $user = User::addUser([
+            'name' => 'To Delete',
+            'email' => 'delete.user@erp.test',
+            'password' => 'secret123',
+            'role' => UserRole::STAFF->value,
+        ]);
+
+        $deleted = User::deleteUser($user->id);
+
+        $this->assertEquals(1, $deleted);
+        $this->assertNull(User::find($user->id));
+    }
+}


### PR DESCRIPTION
## Kenapa
Tabel `users` ternyata tidak pernah ada sama sekali di database, dan tidak ada satupun konsep role/permission di project ini. Ini bagian pertama dari 3 PR bertingkat untuk fitur RBAC (2 PR berikutnya menyusul di atas branch ini): middleware role-based access, lalu modul Kelola User.

## Yang ditambahkan
- Migration `users` (kolom `role`, sebelumnya tabel ini tidak ada)
- Enum `UserRole` (Admin/Staff), mengikuti pola `ProductType` yang sudah ada
- Method `addUser`, `updateUser`, `deleteUser`, `getAllUsers` di model `User`
- Konstanta pesan User di `Messages.php` (mengikuti pola pesan Branch/Merk/dst)
- Seeder 2 user contoh (admin@erp.test, staff@erp.test)
- Unit test untuk semua method di atas

## Tidak diubah
Tidak ada file modul lain yang disentuh sama sekali — murni tambahan tabel dan model baru.

## Test plan
- [x] `php artisan migrate` berhasil
- [x] `php artisan test --filter=UserTest` lulus