### PR TITLE
Tambah middleware role-based access control

### DIFF
--- a/app/Http/Middleware/EnsureUserHasRole.php
+++ b/app/Http/Middleware/EnsureUserHasRole.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Enums\UserRole;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserHasRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Usage: ->middleware('role:admin')
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        $user = $request->user();
+
+        if (!$user || !in_array($user->role?->value, $roles, true)) {
+            abort(403, 'Anda tidak memiliki akses untuk halaman ini.');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\EnsureUserHasRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
## Kenapa
Bagian 2 dari 3 PR bertingkat untuk fitur RBAC (di atas PR "Tambah fondasi tabel users dan role"). Menyiapkan middleware pengecekan role sebagai infrastruktur siap pakai.

## Yang ditambahkan
- `EnsureUserHasRole` middleware, didaftarkan sebagai alias `role` di `bootstrap/app.php` (closure-nya sebelumnya kosong)
- Belum dipasang ke rute manapun — belum ada login asli untuk diautentikasi, jadi ini disiapkan untuk dipakai nanti setelah login sungguhan ada

## Tidak diubah
Tidak ada rute atau file modul lain yang disentuh.

## Test plan
- [x] `php -l` bersih untuk kedua file