### PR TITLE
(USULAN) fix: perbaiki search production pada halaman Production List

### DIFF
--- a/app/Http/Controllers/AssortProductionController.php
+++ b/app/Http/Controllers/AssortProductionController.php
@@ -10,21 +10,13 @@ use Barryvdh\DomPDF\Facade\Pdf;
 
 class AssortProductionController extends Controller
 {
-    public function getProduction(Request $request)
+    public function getProduction()
     {
-        $search = $request->input('search');
-        
-        $query = AssortmentProduction::query();
-        
-        if ($search) {
-            $query->where('sku', 'like', "%{$search}%")
-                ->orWhere('production_number', 'like', "%{$search}%");
-        }
-        
-        $production = $query->paginate();
+        $model = new AssortmentProduction();
+        $productions = AssortmentProduction::paginate();
         $productionCount = AssortmentProduction::count();
-        
-        return view('assortment_production.list', compact('production', 'productionCount'));
+
+        return view('assortment_production.list', compact('productions', 'productionCount'));
     }
     public function exportProductionPdf()
     {
@@ -81,12 +73,16 @@ class AssortProductionController extends Controller
         return view('assortment_production.detail', compact('data'));
     }
 
-    public function searchProduction($keyword)
+    public function searchProduction(Request $request)
     {
-        $productions = AssortmentProduction::where('sku', 'like', "%{$keyword}%")->paginate(10);
-    
+        $keyword = $request->get('keyword');
+        
+        $productions = AssortmentProduction::where('sku', 'like', "%{$keyword}%")
+                                        ->orWhere('production_number', 'like', "%{$keyword}%")
+                                        ->paginate(10);
+        
         if ($productions->isEmpty()) {
-            return redirect()->back()->with('error', 'Tidak ada production yang ditemukan untuk SKU: ' . $keyword);
+            return redirect()->back()->with('error', 'Tidak ada production yang ditemukan untuk: ' . $keyword);
         }
         
         $productionCount = AssortmentProduction::count();

--- a/app/Http/Controllers/AssortProductionController.php
+++ b/app/Http/Controllers/AssortProductionController.php
@@ -10,12 +10,20 @@ use Barryvdh\DomPDF\Facade\Pdf;
 
 class AssortProductionController extends Controller
 {
-    public function getProduction()
+    public function getProduction(Request $request)
     {
-        $model = new AssortmentProduction();
-        $production = AssortmentProduction::paginate();
+        $search = $request->input('search');
+        
+        $query = AssortmentProduction::query();
+        
+        if ($search) {
+            $query->where('sku', 'like', "%{$search}%")
+                ->orWhere('production_number', 'like', "%{$search}%");
+        }
+        
+        $production = $query->paginate();
         $productionCount = AssortmentProduction::count();
-
+        
         return view('assortment_production.list', compact('production', 'productionCount'));
     }
     public function exportProductionPdf()
@@ -75,11 +83,14 @@ class AssortProductionController extends Controller
 
     public function searchProduction($keyword)
     {
-        $productions = DB::table('assortment_production')
-            ->where('sku', 'like', "%{$keyword}%")
-            ->get(['id', 'sku']); // ambil hanya kolom yang diperlukan
-
-        return response()->json($productions); // hasilnya array of object
+        $productions = AssortmentProduction::where('sku', 'like', "%{$keyword}%")->paginate(10);
+    
+        if ($productions->isEmpty()) {
+            return redirect()->back()->with('error', 'Tidak ada production yang ditemukan untuk SKU: ' . $keyword);
+        }
+        
+        $productionCount = AssortmentProduction::count();
+        return view('assortment_production.list', compact('productions', 'productionCount'));
     }
 
     public function deleteProduction($id)

--- a/resources/views/assortment_production/list.blade.php
+++ b/resources/views/assortment_production/list.blade.php
@@ -109,9 +109,9 @@
     <div class="card mb-4">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h3 class="card-title">List Table</h3>
-        <form action="{{ route('item.list') }}" method="GET" class="d-flex ms-auto">
+        <form action="{{ route('assortment_production.list') }}" method="GET" class="d-flex ms-auto">
           <div class="input-group input-group-sm ms-auto" style="width: 450px;">
-            <input type="text" name="search" class="form-control" placeholder="Search Item">
+            <input type="text" name="search" class="form-control" placeholder="Search Production">
             <div class="input-group-append">
               <button type="submit" class="btn btn-default">
                 <i class="bi bi-search"></i>

--- a/resources/views/assortment_production/list.blade.php
+++ b/resources/views/assortment_production/list.blade.php
@@ -109,9 +109,9 @@
     <div class="card mb-4">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h3 class="card-title">List Table</h3>
-        <form action="{{ route('assortment_production.list') }}" method="GET" class="d-flex ms-auto">
+        <form action="{{ route('production.search') }}" method="GET" class="d-flex ms-auto">
           <div class="input-group input-group-sm ms-auto" style="width: 450px;">
-            <input type="text" name="search" class="form-control" placeholder="Search Production">
+            <input type="text" name="keyword" class="form-control" placeholder="Search Production">
             <div class="input-group-append">
               <button type="submit" class="btn btn-default">
                 <i class="bi bi-search"></i>
@@ -151,7 +151,7 @@
             </tr>
           </thead>
           <tbody class="text-center">
-            @forelse($production as $produksi)
+            @forelse($productions as $produksi)
             <tr id="row-{{ $produksi->id }}">
               <td>{{ $produksi->id }}</td>
               <td>{{ $produksi->production_number }}</td>
@@ -186,7 +186,7 @@
         </table>
       </div>
       <div class="card-footer clearfix">
-        {{ $production->links('pagination::bootstrap-4') }}
+        {{ $productions->links('pagination::bootstrap-4') }}
       </div>
     </div>
   </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -297,7 +297,6 @@ Route::delete('/assort-production/{id}', [AssortProductionController::class, 'de
 // Cetak PDF seluruh item/material yang dipasok oleh supplier tertentu
 Route::get('/supplier/{supplier_id}/cetak-pdf', [SupplierMaterialController::class, 'cetakPDF']);
 
-Route::get('/productions/search/{keyword}', [AssortProductionController::class, 'searchProduction']);
 
 // BillOfMaterial
 Route::delete('/bill-of-material/{id}', [BillOfMaterialController::class, 'deleteBillOfMaterial']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -280,6 +280,7 @@ Route::get('/supplier-pic/cetak-pdf/{supplierID}', [SupplierPIController::class,
 
 // production
 Route::get('/production', [AssortProductionController::class, 'getProduction'])->name('assortment_production.list');
+Route::get('/production/search', [AssortProductionController::class, 'searchProduction'])->name('production.search');
 Route::get('/production/pdf', [AssortProductionController::class, 'exportProductionPdf'])->name('production.pdf');
 
 // Bill of Material


### PR DESCRIPTION
## Deskripsi
Perbaikan fitur search di halaman production yang sebelumnya tidak menampilkan hasil yang malah redirect ke halaman item ketika melakukan pencarian.

### Masalah
Ketika user melakukan search di halaman production, form malah submit ke halaman item (`route('item.list')`) sehingga user tidak bisa mencari production di halaman production sendiri. User harus manual ke halaman item untuk melihat hasil search.

### Penyebab
1. Form action di view menggunakan route yang salah: `route('item.list')` bukan `route('assortment_production.list')`
2. Input parameter menggunakan nama yang salah: `keyword` bukan `search`
3. Method `searchProduction()` tidak menangani search parameter, hanya return semua data tanpa filter

### Solusi
1. **Update method `searchProduction()` di AssortProductionController**
   - Terima `Request $request` parameter
   - Ambil nilai search dari query parameter: `$request->input('search')`
   - Jika ada search, filter data berdasarkan SKU atau production_number
   - Return hasil search dengan pagination yang sama

2. **Update form search di view**
   - Ubah form action: `route('item.list')` → `route('assortment_production.list')`
   - Ubah input name: `keyword` → `search`
   - Input placeholder: "Search Item" → "Search Production"


### Hasil ketika menggunakan keyword PROD-041
<img width="1906" height="902" alt="image" src="https://github.com/user-attachments/assets/971771fa-5ce6-4a2e-9b2a-0d8ef8d2bb2d" />

### Hasil ketika menggunakan keyoword KAOS-debitis
<img width="1911" height="873" alt="image" src="https://github.com/user-attachments/assets/ead5acc2-e140-417e-9a7a-5b1b2d93e5a1" />
