### PR TITLE
254_fitur payment PO

### DIFF
--- a/app/Constants/ActivityLogColumns.php
+++ b/app/Constants/ActivityLogColumns.php
@@ -40,6 +40,7 @@ class ActivityLogColumns
     const MODULE_GRN = 'goods_receipt_note';
     const MODULE_GOODS_RETURN = 'goods_return';
     const MODULE_USER = 'user';
+    const MODULE_PO_PAYMENT = 'po_payment';
 
     /**
      * Mendapatkan daftar kolom yang bisa diisi (fillable).
@@ -90,6 +91,7 @@ class ActivityLogColumns
             self::MODULE_GRN => 'Goods Receipt Note',
             self::MODULE_GOODS_RETURN => 'Goods Return',
             self::MODULE_USER => 'User',
+            self::MODULE_PO_PAYMENT => 'Pembayaran PO',
         ];
     }
 }

--- a/app/Constants/Messages.php
+++ b/app/Constants/Messages.php
@@ -83,6 +83,10 @@ class Messages
     public const PO_DELETED = 'Purchase Order berhasil dihapus.';
     public const PO_DELETE_FAILED = 'Gagal menghapus Purchase Order: ';
 
+    // Purchase Order Payment messages
+    public const PO_PAYMENT_CREATED = 'Pembayaran berhasil dicatat!';
+    public const PO_PAYMENT_NOT_FOUND = 'Data pembayaran tidak ditemukan';
+
     // User messages
     public const USER_NOT_FOUND = 'User tidak ditemukan';
     public const USER_CREATED = 'User berhasil ditambahkan!';

--- a/app/Http/Controllers/PurchaseOrderPaymentController.php
+++ b/app/Http/Controllers/PurchaseOrderPaymentController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StorePurchaseOrderPaymentRequest;
+use App\Models\ActivityLog;
+use App\Constants\ActivityLogColumns;
+use App\Constants\Messages;
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderPayment;
+use Illuminate\Http\Request;
+
+class PurchaseOrderPaymentController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->input('search');
+        $payments = PurchaseOrderPayment::getPayments($search);
+
+        return view('purchase_order_payment.index', compact('payments', 'search'));
+    }
+
+    public function create()
+    {
+        $purchaseOrders = PurchaseOrder::with('supplier')
+            ->orderBy('order_date', 'desc')
+            ->get()
+            ->map(function ($po) {
+                $po->paid_amount = PurchaseOrderPayment::getTotalPaid($po->po_number);
+                $po->remaining_amount = $po->total - $po->paid_amount;
+
+                return $po;
+            })
+            ->filter(fn ($po) => $po->remaining_amount > 0);
+
+        return view('purchase_order_payment.create', compact('purchaseOrders'));
+    }
+
+    public function store(StorePurchaseOrderPaymentRequest $request)
+    {
+        $payment = PurchaseOrderPayment::addPayment($request->validated());
+
+        ActivityLog::logActivity(
+            ActivityLogColumns::ACTION_CREATE,
+            ActivityLogColumns::MODULE_PO_PAYMENT,
+            "Mencatat pembayaran PO '{$payment->po_number}' sebesar {$payment->amount}",
+            $payment->id
+        );
+
+        return redirect()->route('po-payments.show', $payment->id)
+            ->with('success', Messages::PO_PAYMENT_CREATED);
+    }
+
+    public function show($id)
+    {
+        $payment = PurchaseOrderPayment::with('purchaseOrder.supplier')->find($id);
+
+        if (! $payment) {
+            return abort(404, Messages::PO_PAYMENT_NOT_FOUND);
+        }
+
+        $paidAmount = PurchaseOrderPayment::getTotalPaid($payment->po_number);
+        $remainingAmount = ($payment->purchaseOrder->total ?? 0) - $paidAmount;
+
+        return view('purchase_order_payment.show', compact('payment', 'paidAmount', 'remainingAmount'));
+    }
+}

--- a/app/Http/Requests/StorePurchaseOrderPaymentRequest.php
+++ b/app/Http/Requests/StorePurchaseOrderPaymentRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePurchaseOrderPaymentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'po_number' => 'required|string|exists:purchase_order,po_number',
+            'payment_date' => 'required|date|before_or_equal:today',
+            'amount' => 'required|integer|min:1',
+            'method' => 'nullable|string|max:50',
+            'note' => 'nullable|string|max:255',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'po_number.required' => 'Purchase Order wajib dipilih.',
+            'po_number.exists' => 'Purchase Order tidak ditemukan.',
+            'payment_date.required' => 'Tanggal pembayaran wajib diisi.',
+            'payment_date.before_or_equal' => 'Tanggal pembayaran tidak boleh melebihi hari ini.',
+            'amount.required' => 'Jumlah pembayaran wajib diisi.',
+            'amount.min' => 'Jumlah pembayaran minimal 1.',
+            'method.max' => 'Metode pembayaran maksimal 50 karakter.',
+            'note.max' => 'Catatan maksimal 255 karakter.',
+        ];
+    }
+}

--- a/app/Models/PurchaseOrderPayment.php
+++ b/app/Models/PurchaseOrderPayment.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class PurchaseOrderPayment extends Model
+{
+    protected $table;
+
+    protected $fillable = [];
+
+    protected $casts = [
+        'payment_date' => 'date',
+        'amount' => 'integer',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->table = config('db_constants.table.po_payment');
+        $this->fillable = array_values(config('db_constants.column.po_payment') ?? []);
+    }
+
+    public function purchaseOrder()
+    {
+        return $this->belongsTo(PurchaseOrder::class, 'po_number', 'po_number');
+    }
+
+    public static function getPayments($search = null)
+    {
+        $query = self::with('purchaseOrder.supplier');
+
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('po_number', 'LIKE', "%{$search}%")
+                    ->orWhere('method', 'LIKE', "%{$search}%")
+                    ->orWhere('note', 'LIKE', "%{$search}%");
+            });
+        }
+
+        return $query->orderBy('payment_date', 'desc')
+            ->orderBy('id', 'desc')
+            ->paginate(10)
+            ->withQueryString();
+    }
+
+    public static function getTotalPaid($poNumber)
+    {
+        return (int) self::where('po_number', $poNumber)->sum('amount');
+    }
+
+    public static function addPayment(array $data)
+    {
+        return DB::transaction(function () use ($data) {
+            $po = PurchaseOrder::where('po_number', $data['po_number'])
+                ->lockForUpdate()
+                ->first();
+
+            if (! $po) {
+                throw ValidationException::withMessages([
+                    'po_number' => 'Purchase Order tidak ditemukan.',
+                ]);
+            }
+
+            if (Carbon::parse($data['payment_date'])->lt(Carbon::parse($po->order_date))) {
+                throw ValidationException::withMessages([
+                    'payment_date' => 'Tanggal pembayaran tidak boleh lebih awal dari tanggal order PO.',
+                ]);
+            }
+
+            $alreadyPaid = self::where('po_number', $po->po_number)
+                ->lockForUpdate()
+                ->sum('amount');
+
+            $remaining = $po->total - $alreadyPaid;
+
+            if ($remaining <= 0) {
+                throw ValidationException::withMessages([
+                    'po_number' => 'Purchase Order ini sudah lunas.',
+                ]);
+            }
+
+            if ($data['amount'] > $remaining) {
+                throw ValidationException::withMessages([
+                    'amount' => "Jumlah pembayaran melebihi sisa tagihan (maksimal {$remaining}).",
+                ]);
+            }
+
+            return self::create([
+                'po_number' => $po->po_number,
+                'payment_date' => $data['payment_date'],
+                'amount' => $data['amount'],
+                'method' => $data['method'] ?? null,
+                'note' => $data['note'] ?? null,
+            ]);
+        });
+    }
+}

--- a/config/db_constants.php
+++ b/config/db_constants.php
@@ -30,6 +30,7 @@ return [
         'mu'                        => 'measurement_unit',
         'po'                        => 'purchase_order',
         'po_detail'                 => 'purchase_order_detail',
+        'po_payment'                => 'purchase_order_payments',
         'products'                   => 'products',
         'supplier'                  => 'suppliers',
         'supplier_pic'              => 'supplier_pics',
@@ -220,6 +221,16 @@ return [
             'quantity'              => 'quantity',
             'amount'                => 'amount',
             'received_days'         => 'received_days',
+            'created_at'            => 'created_at',
+            'updated_at'            => 'updated_at'
+        ],
+        'po_payment' => [
+            'id'                    => 'id',
+            'po_number'             => $master['po_number'],
+            'payment_date'          => 'payment_date',
+            'amount'                => 'amount',
+            'method'                => 'method',
+            'note'                  => 'note',
             'created_at'            => 'created_at',
             'updated_at'            => 'updated_at'
         ],

--- a/database/migrations/2026_07_22_000001_create_purchase_order_payments_table.php
+++ b/database/migrations/2026_07_22_000001_create_purchase_order_payments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function __construct()
+    {
+        $this->table = config('db_constants.table.po_payment');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $col = config('db_constants.column.po_payment');
+
+        Schema::create($this->table, function (Blueprint $table) use ($col) {
+            $table->id();
+            $table->char($col['po_number'], 6);
+            $table->date($col['payment_date']);
+            $table->bigInteger($col['amount']);
+            $table->string($col['method'], 50)->nullable();
+            $table->string($col['note'], 255)->nullable();
+            $table->timestamps();
+
+            $table->index($col['po_number']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists($this->table);
+    }
+};

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -1,6 +1,6 @@
 @php
     $isSupplier = request()->routeIs('supplier.*');
-    $isPurchaseOrder = request()->routeIs('purchase.orders*') || request()->routeIs('purchase_orders.*') || request()->routeIs('goods-returns.*');
+    $isPurchaseOrder = request()->routeIs('purchase.orders*') || request()->routeIs('purchase_orders.*') || request()->routeIs('goods-returns.*') || request()->routeIs('po-payments.*');
     $isProduction = request()->routeIs('bom.*') || request()->routeIs('billofmaterial.*') || request()->routeIs('assort*');
     $isItem = request()->routeIs('item.*') || request()->routeIs('items.*');
 @endphp
@@ -102,6 +102,12 @@
                             <a href="{{ route('goods-returns.index') }}" class="nav-link @if(request()->routeIs('goods-returns.*')) active @endif">
                                 <i class="nav-icon bi bi-circle"></i>
                                 <p>Return Barang</p>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="{{ route('po-payments.index') }}" class="nav-link @if(request()->routeIs('po-payments.*')) active @endif">
+                                <i class="nav-icon bi bi-circle"></i>
+                                <p>Pembayaran PO</p>
                             </a>
                         </li>
                     </ul>

--- a/resources/views/purchase_order_payment/create.blade.php
+++ b/resources/views/purchase_order_payment/create.blade.php
@@ -1,0 +1,133 @@
+@extends('layouts.app')
+
+@section('title', 'Tambah Pembayaran PO')
+
+@section('page-title')
+    <h3 class="mb-0">Tambah Pembayaran PO</h3>
+@endsection
+
+@section('breadcrumb')
+    <li class="breadcrumb-item"><a href="{{ route('po-payments.index') }}">Pembayaran PO</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Tambah</li>
+@endsection
+
+@section('content')
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card card-primary">
+                <div class="card-header">
+                    <h3 class="card-title">Formulir Pembayaran Purchase Order</h3>
+                </div>
+
+                <form action="{{ route('po-payments.store') }}" method="POST">
+                    @csrf
+                    <div class="card-body">
+                        @if ($errors->any())
+                            <div class="alert alert-danger">
+                                <ul class="mb-0">
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        <div class="mb-3">
+                            <label for="po_number" class="form-label">Purchase Order <span class="text-danger">*</span></label>
+                            <select name="po_number" id="po_number" class="form-select @error('po_number') is-invalid @enderror" required>
+                                <option value="">Pilih Purchase Order yang belum lunas</option>
+                                @foreach ($purchaseOrders as $po)
+                                    <option
+                                        value="{{ $po->po_number }}"
+                                        data-supplier="{{ $po->supplier?->company_name ?? '-' }}"
+                                        data-total="{{ $po->total }}"
+                                        data-paid="{{ $po->paid_amount }}"
+                                        data-remaining="{{ $po->remaining_amount }}"
+                                        data-order-date="{{ $po->order_date }}"
+                                        {{ (string) old('po_number') === (string) $po->po_number ? 'selected' : '' }}
+                                    >
+                                        {{ $po->po_number }} | {{ $po->supplier?->company_name ?? '-' }} | Sisa {{ number_format($po->remaining_amount, 0, ',', '.') }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            @if ($purchaseOrders->isEmpty())
+                                <small class="text-danger">Tidak ada Purchase Order yang masih memiliki tagihan.</small>
+                            @endif
+                        </div>
+
+                        <div id="poInformation" class="alert alert-info d-none">
+                            <div><strong>Supplier:</strong> <span id="poSupplier">-</span></div>
+                            <div><strong>Total PO:</strong> <span id="poTotal">0</span></div>
+                            <div><strong>Sudah Dibayar:</strong> <span id="poPaid">0</span></div>
+                            <div><strong>Sisa Tagihan:</strong> <span id="poRemaining">0</span></div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="payment_date" class="form-label">Tanggal Pembayaran <span class="text-danger">*</span></label>
+                                <input type="date" name="payment_date" id="payment_date" class="form-control @error('payment_date') is-invalid @enderror" value="{{ old('payment_date', now()->format('Y-m-d')) }}" max="{{ now()->format('Y-m-d') }}" required>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="amount" class="form-label">Jumlah Pembayaran <span class="text-danger">*</span></label>
+                                <input type="number" name="amount" id="amount" class="form-control @error('amount') is-invalid @enderror" value="{{ old('amount') }}" min="1" required>
+                                <small id="amountHelp" class="form-text text-secondary">Pilih Purchase Order terlebih dahulu.</small>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="method" class="form-label">Metode Pembayaran</label>
+                            <input type="text" name="method" id="method" class="form-control @error('method') is-invalid @enderror" placeholder="Contoh: Transfer Bank, Cash" value="{{ old('method') }}">
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="note" class="form-label">Catatan</label>
+                            <textarea name="note" id="note" rows="3" maxlength="255" class="form-control @error('note') is-invalid @enderror" placeholder="Catatan tambahan (opsional)">{{ old('note') }}</textarea>
+                        </div>
+                    </div>
+
+                    <div class="card-footer">
+                        <button type="submit" class="btn btn-primary" {{ $purchaseOrders->isEmpty() ? 'disabled' : '' }}>
+                            <i class="bi bi-save"></i> Simpan Pembayaran
+                        </button>
+                        <a href="{{ route('po-payments.index') }}" class="btn btn-secondary">Batal</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var poSelect = document.getElementById('po_number');
+    var amountInput = document.getElementById('amount');
+    var paymentDateInput = document.getElementById('payment_date');
+    var poInformation = document.getElementById('poInformation');
+
+    function updatePoInformation() {
+        var option = poSelect.options[poSelect.selectedIndex];
+
+        if (!option || !option.value) {
+            poInformation.classList.add('d-none');
+            amountInput.removeAttribute('max');
+            paymentDateInput.removeAttribute('min');
+            document.getElementById('amountHelp').textContent = 'Pilih Purchase Order terlebih dahulu.';
+            return;
+        }
+
+        document.getElementById('poSupplier').textContent = option.dataset.supplier;
+        document.getElementById('poTotal').textContent = option.dataset.total;
+        document.getElementById('poPaid').textContent = option.dataset.paid;
+        document.getElementById('poRemaining').textContent = option.dataset.remaining;
+        amountInput.max = option.dataset.remaining;
+        paymentDateInput.min = option.dataset.orderDate;
+        document.getElementById('amountHelp').textContent = 'Maksimal: ' + option.dataset.remaining;
+        poInformation.classList.remove('d-none');
+    }
+
+    poSelect.addEventListener('change', updatePoInformation);
+    updatePoInformation();
+});
+</script>
+@endpush

--- a/resources/views/purchase_order_payment/index.blade.php
+++ b/resources/views/purchase_order_payment/index.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('title', 'Pembayaran PO')
+
+@section('page-title')
+    <h3 class="mb-0 me-2">Pembayaran PO</h3>
+    <a href="{{ route('po-payments.create') }}" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-circle"></i> Tambah Pembayaran
+    </a>
+@endsection
+
+@section('breadcrumb')
+    <li class="breadcrumb-item active" aria-current="page">Pembayaran PO</li>
+@endsection
+
+@section('content')
+    @if (session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="card-title">Daftar Pembayaran PO</h3>
+            <form action="{{ route('po-payments.index') }}" method="GET" class="d-flex ms-auto">
+                <div class="input-group input-group-sm" style="width: 360px;">
+                    <input type="text" name="search" class="form-control" placeholder="Cari PO, metode, atau catatan" value="{{ $search }}">
+                    <button type="submit" class="btn btn-default">
+                        <i class="bi bi-search"></i>
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <div class="card-body table-responsive">
+            <table class="table table-bordered table-striped align-middle">
+                <thead class="text-center">
+                    <tr>
+                        <th>No</th>
+                        <th>Purchase Order</th>
+                        <th>Supplier</th>
+                        <th>Tanggal Bayar</th>
+                        <th>Jumlah</th>
+                        <th>Metode</th>
+                        <th>Aksi</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($payments as $index => $payment)
+                        <tr>
+                            <td class="text-center">{{ $payments->firstItem() + $index }}</td>
+                            <td>{{ $payment->po_number }}</td>
+                            <td>{{ $payment->purchaseOrder?->supplier?->company_name ?? '-' }}</td>
+                            <td>{{ $payment->payment_date->format('d/m/Y') }}</td>
+                            <td class="text-end">{{ number_format($payment->amount, 0, ',', '.') }}</td>
+                            <td>{{ $payment->method ?? '-' }}</td>
+                            <td class="text-center">
+                                <a href="{{ route('po-payments.show', $payment->id) }}" class="btn btn-info btn-sm">
+                                    Detail
+                                </a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="text-center">Belum ada data pembayaran.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if ($payments->hasPages())
+            <div class="card-footer">
+                {{ $payments->links() }}
+            </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/purchase_order_payment/show.blade.php
+++ b/resources/views/purchase_order_payment/show.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('title', 'Detail Pembayaran PO')
+
+@section('page-title')
+    <h3 class="mb-0">Detail Pembayaran PO</h3>
+@endsection
+
+@section('breadcrumb')
+    <li class="breadcrumb-item"><a href="{{ route('po-payments.index') }}">Pembayaran PO</a></li>
+    <li class="breadcrumb-item active" aria-current="page">#{{ $payment->id }}</li>
+@endsection
+
+@section('content')
+    @if (session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="card-title">Informasi Pembayaran #{{ $payment->id }}</h3>
+                </div>
+                <div class="card-body">
+                    <table class="table table-bordered">
+                        <tr>
+                            <th style="width: 35%">Purchase Order</th>
+                            <td>{{ $payment->po_number }}</td>
+                        </tr>
+                        <tr>
+                            <th>Supplier</th>
+                            <td>{{ $payment->purchaseOrder?->supplier?->company_name ?? 'Tidak ada data' }}</td>
+                        </tr>
+                        <tr>
+                            <th>Tanggal Pembayaran</th>
+                            <td>{{ $payment->payment_date->format('d/m/Y') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Jumlah Dibayar</th>
+                            <td>{{ number_format($payment->amount, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Metode</th>
+                            <td>{{ $payment->method ?? '-' }}</td>
+                        </tr>
+                        <tr>
+                            <th>Catatan</th>
+                            <td>{{ $payment->note ?? '-' }}</td>
+                        </tr>
+                        <tr>
+                            <th>Total PO</th>
+                            <td>{{ number_format($payment->purchaseOrder?->total ?? 0, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Total Sudah Dibayar</th>
+                            <td>{{ number_format($paidAmount, 0, ',', '.') }}</td>
+                        </tr>
+                        <tr>
+                            <th>Sisa Tagihan</th>
+                            <td>
+                                @if($remainingAmount <= 0)
+                                    <span class="badge bg-success">Lunas</span>
+                                @else
+                                    {{ number_format($remainingAmount, 0, ',', '.') }}
+                                @endif
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Dicatat Pada</th>
+                            <td>{{ $payment->created_at->format('d/m/Y H:i:s') }}</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="card-footer">
+                    <a href="{{ route('po-payments.index') }}" class="btn btn-secondary">
+                        <i class="bi bi-arrow-left"></i> Kembali
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\ItemController;
 use App\Http\Controllers\MerkController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\PurchaseOrderController;
+use App\Http\Controllers\PurchaseOrderPaymentController;
 use App\Http\Controllers\SupplierController;
 use App\Http\Controllers\SupplierMaterialController;
 use App\Http\Controllers\SupplierPIController;
@@ -349,6 +350,12 @@ Route::get('/goods-returns/create', [GoodsReturnController::class, 'create'])->n
 Route::post('/goods-returns', [GoodsReturnController::class, 'store'])->name('goods-returns.store');
 Route::get('/goods-returns/{id}/pdf', [GoodsReturnController::class, 'printPdf'])->name('goods-returns.pdf');
 Route::get('/goods-returns/{id}', [GoodsReturnController::class, 'show'])->name('goods-returns.show');
+
+// Purchase Order Payment
+Route::get('/po-payments', [PurchaseOrderPaymentController::class, 'index'])->name('po-payments.index');
+Route::get('/po-payments/create', [PurchaseOrderPaymentController::class, 'create'])->name('po-payments.create');
+Route::post('/po-payments', [PurchaseOrderPaymentController::class, 'store'])->name('po-payments.store');
+Route::get('/po-payments/{id}', [PurchaseOrderPaymentController::class, 'show'])->name('po-payments.show');
 
 // Get Product By Category Controller
 Route::get('/products/category/{product_category}', [ProductController::class, 'getProductByCategory']);


### PR DESCRIPTION
## Ringkasan
Menambahkan tracking pembayaran Purchase Order ke supplier: catat pembayaran (bisa bertahap/termin), lihat sisa tagihan, cegah pembayaran melebihi total PO.

Eksplisit disebut sebagai modul yang dibutuhkan di PRD (docs/PRD.md — Supplier & Supplier PIC, Integration Requirements: *"...digunakan sebagai reference di modul Purchase Order, Inventory, Payment"*), berbeda dengan fitur sebelumnya (Customer) yang ternyata di luar scope PRD.

Mengikuti pola `GoodsReturn` (validasi transaksional dengan `DB::transaction` + `lockForUpdate`, `ValidationException` untuk business rule) dan `PurchaseOrder` (pakai `config('db_constants.table/column')`).

## Yang ditambahkan
- Migration `purchase_order_payments`
- Model `PurchaseOrderPayment` (+ business rule: tolak lebih-bayar, tolak tanggal sebelum order_date PO, tolak bayar PO yang sudah lunas)
- Controller `PurchaseOrderPaymentController` (index, create, store, show)
- Form request validasi `StorePurchaseOrderPaymentRequest`
- Views: list pembayaran, form tambah pembayaran, detail pembayaran
- Menu sidebar "Pembayaran PO" di bawah submenu Purchase Orders
- Activity log tercatat otomatis tiap pembayaran baru

## Test plan
- [x] Migration jalan bersih
- [x] Bayar sebagian PO lewat model — berhasil
- [x] Coba bayar melebihi sisa tagihan — ditolak dengan pesan jelas
- [x] Coba bayar dengan tanggal sebelum order_date PO — ditolak
- [x] Lunasi sisa tagihan — berhasil, status jadi Lunas
- [x] Coba bayar PO yang sudah lunas — ditolak
- [x] Submit form asli lewat HTTP (bukan cuma tinker) — berhasil, redirect ke detail
- [x] Activity log tercatat untuk aksi create
- [x] Data uji dibersihkan setelah testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)